### PR TITLE
Add name to zig_lint

### DIFF
--- a/.github/workflows/zig-build-lint-and-test-on-pr-and-push.yml
+++ b/.github/workflows/zig-build-lint-and-test-on-pr-and-push.yml
@@ -49,7 +49,7 @@ jobs:
       working-directory: bindings/python
 
   zig_lint:
-    name: Zig Build and Test
+    name: Zig Lint
 
     # Microsoft Windows disagrees with the Unix-like systems about formatting.
     runs-on: ${{ matrix.operating-system }}


### PR DESCRIPTION
This PR adds a adds name to the `zig_lint` GitHub Actions job.