### PR TITLE
Add decompress() and Configuration

### DIFF
--- a/bindings/python/tersets/__init__.py
+++ b/bindings/python/tersets/__init__.py
@@ -83,9 +83,8 @@ def compress(values: List[float]) -> bytes:
         uncompressed_values, byref(compressed_values), configuration
     )
 
-    match error:
-        case 1:
-            raise ValueError("Unknown compression method.")
+    if error == 1:
+        raise ValueError("Unknown compression method.")
 
     return compressed_values.data[: compressed_values.len]
 
@@ -105,8 +104,7 @@ def decompress(values: bytes) -> List[float]:
         compressed_values, byref(decompressed_values), configuration
     )
 
-    match error:
-        case 1:
-            raise ValueError("Unknown decompression method.")
+    if error == 1:
+        raise ValueError("Unknown decompression method.")
 
     return decompressed_values.data[: decompressed_values.len]

--- a/bindings/python/tests/__init__.py
+++ b/bindings/python/tests/__init__.py
@@ -12,13 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+import sys
+import random
 import unittest
 
-from tersets import compress
+from tersets import compress, decompress
+
+# Number of values to generate for each test.
+TEST_VALUE_COUNT = 1000
 
 
 class TerseTSPythonTest(unittest.TestCase):
-    def test_compress(self):
-        values = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
-        self.assertEqual(compress(values), 0)
+    def test_compress_and_decompress(self):
+        uncompressed = [
+            random.uniform(sys.float_info.min, sys.float_info.max)
+            for _ in range(0, TEST_VALUE_COUNT)
+        ]
+        compressed = compress(uncompressed)
+        decompressed = decompress(compressed)
+        self.assertEqual(uncompressed, decompressed)

--- a/src/tersets.zig
+++ b/src/tersets.zig
@@ -19,10 +19,10 @@ const math = std.math;
 const testing = std.testing;
 
 /// A pointer to uncompressed values and the number of values.
-pub const UncompressedValues = extern struct { data: [*]const f64, len: usize }; //Array(f64);
+pub const UncompressedValues = Array(f64);
 
 /// A pointer to compressed values and the number of bytes.
-pub const CompressedValues = extern struct { data: [*]const u8, len: usize }; //Array(u8);
+pub const CompressedValues = Array(u8);
 
 /// Configuration to use for compression and/or decompression.
 pub const Configuration = extern struct { method: u8, error_bound: f32 };
@@ -31,13 +31,10 @@ pub const Configuration = extern struct { method: u8, error_bound: f32 };
 /// `configuration`. The following non-zero values are returned on errors:
 /// - 1) Unsupported compression method.
 export fn compress(
-    uncompressed_values: *const UncompressedValues,
+    uncompressed_values: UncompressedValues,
     compressed_values: *CompressedValues,
     configuration: Configuration,
 ) i32 {
-    std.debug.print("{}\n", .{uncompressed_values});
-    std.debug.print("{}\n", .{compressed_values});
-    std.debug.print("{}\n", .{configuration});
     switch (configuration.method) {
         0 => {
             compressed_values.data = @ptrCast(uncompressed_values.data);
@@ -53,7 +50,7 @@ export fn compress(
 /// `configuration`. The following non-zero values are returned on errors:
 /// - 1) Unsupported decompression method.
 export fn decompress(
-    compressed_values: *const CompressedValues,
+    compressed_values: CompressedValues,
     uncompressed_values: *UncompressedValues,
     configuration: Configuration,
 ) i32 {
@@ -91,14 +88,14 @@ test "compress and decompress" {
     const configuration = Configuration{ .method = 0, .error_bound = 0 };
 
     const compress_result = compress(
-        &uncompressed_values,
+        uncompressed_values,
         &compressed_values,
         configuration,
     );
     try testing.expect(compress_result == 0);
 
     const decompress_result = decompress(
-        &compressed_values,
+        compressed_values,
         &decompressed_values,
         configuration,
     );
@@ -128,7 +125,7 @@ test "error for unknown compression method" {
     configuration.method = math.maxInt(@TypeOf(configuration.method));
 
     const result = compress(
-        &uncompressed_values,
+        uncompressed_values,
         &compressed_values,
         configuration,
     );
@@ -149,7 +146,7 @@ test "error for unknown decompression method" {
     configuration.method = math.maxInt(@TypeOf(configuration.method));
 
     const result = decompress(
-        &compressed_values,
+        compressed_values,
         &uncompressed_values,
         configuration,
     );

--- a/src/tersets.zig
+++ b/src/tersets.zig
@@ -15,41 +15,144 @@
 //! Provides a C-API for TerseTS.
 
 const std = @import("std");
+const math = std.math;
+const testing = std.testing;
 
-/// A pointer to the uncompressed values and the number of values.
-pub const InputData = extern struct { values: [*]const f64, len: usize };
+/// A pointer to uncompressed values and the number of values.
+pub const UncompressedValues = extern struct { data: [*]const f64, len: usize }; //Array(f64);
 
-/// A pointer to the compressed values and the number of bytes.
-pub const OutputData = extern struct { values: [*]const u8, len: usize };
+/// A pointer to compressed values and the number of bytes.
+pub const CompressedValues = extern struct { data: [*]const u8, len: usize }; //Array(u8);
 
-/// Compress `input` to `output` using the specified method.
-export fn compress(input_data: *const InputData, output_data: *OutputData) i32 {
-    std.debug.print("{}\n", .{input_data.len});
-    var i: usize = 0;
-    while (i < input_data.len) : (i += 1) {
-        std.debug.print("{} ", .{input_data.values[i]});
+/// Configuration to use for compression and/or decompression.
+pub const Configuration = extern struct { method: u8, error_bound: f32 };
+
+/// Compress `uncompressed_values` to `compressed_values` according to
+/// `configuration`. The following non-zero values are returned on errors:
+/// - 1) Unsupported compression method.
+export fn compress(
+    uncompressed_values: *const UncompressedValues,
+    compressed_values: *CompressedValues,
+    configuration: Configuration,
+) i32 {
+    std.debug.print("{}\n", .{uncompressed_values});
+    std.debug.print("{}\n", .{compressed_values});
+    std.debug.print("{}\n", .{configuration});
+    switch (configuration.method) {
+        0 => {
+            compressed_values.data = @ptrCast(uncompressed_values.data);
+            compressed_values.len = uncompressed_values.len * 8;
+        },
+        else => return 1,
     }
-    std.debug.print("\n", .{});
-
-    output_data.len = input_data.len;
 
     return 0;
 }
 
-test "compress" {
-    const input_values = [_]f64{ 0, 1, 2, 3, 4 };
-    const input_slice = input_values[0..5];
-    const input_data = InputData{
-        .values = input_slice.ptr,
-        .len = input_slice.len,
-    };
+/// Decompress `compressed_values` to `uncompressed_values` according to
+/// `configuration`. The following non-zero values are returned on errors:
+/// - 1) Unsupported decompression method.
+export fn decompress(
+    compressed_values: *const CompressedValues,
+    uncompressed_values: *UncompressedValues,
+    configuration: Configuration,
+) i32 {
+    switch (configuration.method) {
+        0 => {
+            uncompressed_values.data = @alignCast(@ptrCast(compressed_values.data));
+            uncompressed_values.len = compressed_values.len / 8;
+        },
+        else => return 1,
+    }
 
-    const output_values = [_]u8{};
-    const output_slice = output_values[0..0];
-    var output_data = OutputData{
-        .values = output_slice.ptr,
-        .len = output_slice.len,
-    };
+    return 0;
+}
 
-    try std.testing.expect(compress(&input_data, &output_data) == 0);
+/// `Array` is a pointer to values of type `data_type` and the number of values.
+fn Array(comptime data_type: type) type {
+    return extern struct { data: [*]const data_type, len: usize };
+}
+
+test "compress and decompress" {
+    const uncompressed_array = [_]f64{ 0.1, 1.1, 1.9, 2.5, 3.8 };
+    const uncompressed_slice = uncompressed_array[0..5];
+    const uncompressed_values = UncompressedValues{
+        .data = uncompressed_slice.ptr,
+        .len = uncompressed_slice.len,
+    };
+    var compressed_values = CompressedValues{
+        .data = undefined,
+        .len = undefined,
+    };
+    var decompressed_values = UncompressedValues{
+        .data = uncompressed_slice.ptr,
+        .len = uncompressed_slice.len,
+    };
+    const configuration = Configuration{ .method = 0, .error_bound = 0 };
+
+    const compress_result = compress(
+        &uncompressed_values,
+        &compressed_values,
+        configuration,
+    );
+    try testing.expect(compress_result == 0);
+
+    const decompress_result = decompress(
+        &compressed_values,
+        &decompressed_values,
+        configuration,
+    );
+    try testing.expect(decompress_result == 0);
+
+    try testing.expectEqual(decompressed_values.len, uncompressed_values.len);
+
+    var i: usize = 0;
+    while (i < decompressed_values.len) : (i += 1) {
+        try testing.expectEqual(
+            decompressed_values.data[i],
+            uncompressed_values.data[i],
+        );
+    }
+}
+
+test "error for unknown compression method" {
+    var uncompressed_values = UncompressedValues{
+        .data = undefined,
+        .len = undefined,
+    };
+    var compressed_values = CompressedValues{
+        .data = undefined,
+        .len = undefined,
+    };
+    var configuration = Configuration{ .method = 0, .error_bound = 0 };
+    configuration.method = math.maxInt(@TypeOf(configuration.method));
+
+    const result = compress(
+        &uncompressed_values,
+        &compressed_values,
+        configuration,
+    );
+
+    try testing.expectEqual(result, 1);
+}
+
+test "error for unknown decompression method" {
+    var compressed_values = CompressedValues{
+        .data = undefined,
+        .len = undefined,
+    };
+    var uncompressed_values = UncompressedValues{
+        .data = undefined,
+        .len = undefined,
+    };
+    var configuration = Configuration{ .method = 0, .error_bound = 0 };
+    configuration.method = math.maxInt(@TypeOf(configuration.method));
+
+    const result = decompress(
+        &compressed_values,
+        &uncompressed_values,
+        configuration,
+    );
+
+    try testing.expectEqual(result, 1);
 }

--- a/src/tersets.zig
+++ b/src/tersets.zig
@@ -113,7 +113,7 @@ test "compress and decompress" {
 }
 
 test "error for unknown compression method" {
-    var uncompressed_values = UncompressedValues{
+    const uncompressed_values = UncompressedValues{
         .data = undefined,
         .len = undefined,
     };
@@ -134,7 +134,7 @@ test "error for unknown compression method" {
 }
 
 test "error for unknown decompression method" {
-    var compressed_values = CompressedValues{
+    const compressed_values = CompressedValues{
         .data = undefined,
         .len = undefined,
     };


### PR DESCRIPTION
This PR finish implementation of the initial interface for the library by adding the `decompress()` function and `Configuration` struct and updates the Python bindings to match. To allow the interface to be tested, a placeholder "compression" method is implemented that simply reinterpret the 64-bit floating-point values as bytes for compression and reverse for decompression. Of course this placeholder should be removed when the real compression methods are added.