### PR TITLE
Add ReleaseFast

### DIFF
--- a/.github/workflows/zig-build-lint-and-test-on-pr-and-push.yml
+++ b/.github/workflows/zig-build-lint-and-test-on-pr-and-push.yml
@@ -38,8 +38,10 @@ jobs:
       run: zig build -Doptimize=Debug
     - name: Zig Build ReleaseFast
       run: zig build -Doptimize=ReleaseFast
-    - name: Zig Build Test
-      run: zig build test
+    - name: Zig Build Test Debug
+      run: zig build test -Doptimize=Debug
+    - name: Zig Build Test ReleaseFast
+      run: zig build test -Doptimize=ReleaseFast
 
     - name: Install Package
       run: python3 -m pip install .

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+# Copyright 2024 TerseTS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A pre-commit hook that checks if a Zig library with bindings has errors.
+
+# Fail the entire hook immediately if any of the executed commands fails.
+set -e
+
+# Set the profiles to use for all of the tools from Zig that supports it.
+profiles="Debug ReleaseFast"
+
+# Ensure that the following commands does not emit any errors or warnings.
+# - Compilers: zig build
+# - Linters: zig fmt --check .
+# - Tests: zig build test and python3 -m unittest
+for profile in $profiles
+do
+    echo "Profile $profile"
+    echo "Zig Build"
+    zig build -Doptimize=$profile
+    echo
+    echo "Zig Build Test"
+    zig build test -Doptimize=$profile
+    echo
+    echo "Zig Fmt Check"
+    zig fmt --check .
+    echo
+    echo "Python Test"
+    pushd bindings/python > /dev/null
+    python3 -m unittest
+    popd > /dev/null
+done


### PR DESCRIPTION
Add `ReleaseFast` to the GitHub Actions workflow and a Git `pre-commit` hook that run the same tools locally to help avoid creating commits that does not pass.