### PR TITLE
Add header for languages like C, C++, and Obj-C

### DIFF
--- a/.github/workflows/zig-build-lint-and-test-on-pr-and-push.yml
+++ b/.github/workflows/zig-build-lint-and-test-on-pr-and-push.yml
@@ -43,10 +43,17 @@ jobs:
     - name: Zig Build Test ReleaseFast
       run: zig build test -Doptimize=ReleaseFast
 
-    - name: Install Package
+    - name: Clang Compile Header
+      run: clang -Weverything tersets.h
+      working-directory: bindings/c
+    - name: GCC Compile Header
+      run: gcc -Wall -Wextra tersets.h
+      working-directory: bindings/c
+
+    - name: Python Install Package
       run: python3 -m pip install .
       working-directory: bindings/python
-    - name: Run unittest
+    - name: Python Run unittest
       run: python3 -m unittest --verbose
       working-directory: bindings/python
 

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ zig-out
 __pycache__
 TerseTS.egg-info
 build
+*.gch

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ TerseTS can be compiled and cross-compiled from source:
 TODO
 
 # Bindings
-TerseTS provides a C-API that is designed to be simple to wrap. Currently, TerseTS includes bindings for the current programming languages which can be used without installation of any dependencies:
-- [Zig](tersets/capi.zig)
-- [C](tersets/capi.zig)
-- [C++](tersets/capi.zig)
-- [Python](bindings/tersets.py) using [ctypes](https://docs.python.org/3/library/ctypes.html)
+TerseTS provides a C-API that is designed to be simple to wrap. Currently, TerseTS includes bindings for the following programming languages which can be used without installation of any dependencies:
+- [Zig](src/tersets.zig)
+- [C](bindings/c/tersets.h)
+- [C++](bindings/c/tersets.h)
+- [Python](bindings/python/tersets) using [ctypes](https://docs.python.org/3/library/ctypes.html)
 
 # License
 TerseTS is licensed under version 2.0 of the Apache License and a copy of the license is bundled with the program.

--- a/bindings/c/tersets.h
+++ b/bindings/c/tersets.h
@@ -1,0 +1,33 @@
+#include <stdint.h>
+
+// A pointer to uncompressed values and the number of values.
+struct UncompressedValues {
+  double const * const data;
+  uintptr_t const len;
+};
+
+// A pointer to compressed values and the number of bytes.
+struct CompressedValues {
+  uint8_t const * const data;
+  uintptr_t const len;
+};
+
+// Configuration to use for compression and/or decompression.
+struct Configuration {
+  uint8_t const method;
+  float const error_bound;
+};
+
+// Compress uncompressed_values to compressed_values according to
+// configuration. The following non-zero values are returned on errors:
+// - 1) Unsupported compression method.
+int32_t compress(struct UncompressedValues const uncompressed_values,
+                 struct CompressedValues *const compressed_values,
+                 struct Configuration const configuration);
+
+// Decompress compressed_values to uncompressed_values according to
+// configuration. The following non-zero values are returned on errors:
+// - 1) Unsupported decompression method.
+int32_t decompress(struct CompressedValues const compressed_values,
+                   struct UncompressedValues const * const uncompressed_values,
+                   struct Configuration const configuration);

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -23,7 +23,7 @@ set -e
 profiles="Debug ReleaseFast"
 
 # Ensure that the following commands does not emit any errors or warnings.
-# - Compilers: zig build
+# - Compilers: zig build, clang, gcc
 # - Linters: zig fmt --check .
 # - Tests: zig build test and python3 -m unittest
 for profile in $profiles
@@ -37,6 +37,12 @@ do
     echo
     echo "Zig Fmt Check"
     zig fmt --check .
+    echo
+    echo "C Header Compile"
+    pushd bindings/c > /dev/null
+    clang -Weverything tersets.h
+    gcc -Wall -Wextra tersets.h
+    popd > /dev/null 
     echo
     echo "Python Test"
     pushd bindings/python > /dev/null


### PR DESCRIPTION
This PR adds a header file that can be used in C-based languages like C, C++, and Objective-C. Thus, making TerseTS directly usable from these languages without having to manually define prototypes.