### PR TITLE
Implementation of swing filter and swing mid-range 

### DIFF
--- a/.github/workflows/zig-build-lint-and-test-on-pr-and-push.yml
+++ b/.github/workflows/zig-build-lint-and-test-on-pr-and-push.yml
@@ -26,6 +26,7 @@ jobs:
     name: Zig Build and Test
 
     runs-on: ${{ matrix.operating-system }}
+    timeout-minutes: 10
     strategy:
       matrix:
         operating-system: [ubuntu-latest, macos-latest, windows-latest]
@@ -36,7 +37,7 @@ jobs:
     - name: Setup Zig
       uses: goto-bus-stop/setup-zig@v2
       with:
-        version: 0.12.0  # Use a stable Zig version
+        version: 0.11.0  # Use a stable Zig version
         cache: true
 
     - name: Zig Build Debug

--- a/.github/workflows/zig-build-lint-and-test-on-pr-and-push.yml
+++ b/.github/workflows/zig-build-lint-and-test-on-pr-and-push.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Setup Zig
       uses: goto-bus-stop/setup-zig@v2
       with:
-        version: 0.10.1  # Use a stable Zig version
+        version: 0.12  # Use a stable Zig version
         cache: true
 
     - name: Zig Build Debug

--- a/.github/workflows/zig-build-lint-and-test-on-pr-and-push.yml
+++ b/.github/workflows/zig-build-lint-and-test-on-pr-and-push.yml
@@ -37,8 +37,7 @@ jobs:
     - name: Setup Zig
       uses: goto-bus-stop/setup-zig@v2
       with:
-        version: 0.11.0  # Use a stable Zig version
-        cache: true
+        version: 0.12.0  # Use a stable Zig version
 
     - name: Zig Build Debug
       run: zig build -Doptimize=Debug

--- a/.github/workflows/zig-build-lint-and-test-on-pr-and-push.yml
+++ b/.github/workflows/zig-build-lint-and-test-on-pr-and-push.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Setup Zig
       uses: goto-bus-stop/setup-zig@v2
       with:
-        version: 0.12  # Use a stable Zig version
+        version: 0.12.0  # Use a stable Zig version
         cache: true
 
     - name: Zig Build Debug

--- a/.github/workflows/zig-build-lint-and-test-on-pr-and-push.yml
+++ b/.github/workflows/zig-build-lint-and-test-on-pr-and-push.yml
@@ -32,7 +32,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: goto-bus-stop/setup-zig@v2
+
+    - name: Setup Zig
+      uses: goto-bus-stop/setup-zig@v2
+      with:
+        version: 0.10.1  # Use a stable Zig version
+        cache: true
 
     - name: Zig Build Debug
       run: zig build -Doptimize=Debug

--- a/src/functional/poor_mans_compression.zig
+++ b/src/functional/poor_mans_compression.zig
@@ -1,0 +1,99 @@
+// Copyright 2024 TerseTS Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Implementation of "Poor Man’s Compression - Midrange" and "Poor Man’s
+//! Compression - Mean" from the paper "Iosif Lazaridis, Sharad Mehrotra:
+//! Capturing Sensor-Generated Time Series with Quality Guarantees. ICDE 2003:
+//! 429-440".
+
+const std = @import("std");
+const math = std.math;
+const mem = std.mem;
+const testing = std.testing;
+
+const ArrayList = std.ArrayList;
+
+pub fn poorMansCompressionCompress(
+    uncompressed_values: []const f64,
+    compressed_values: *ArrayList(u8),
+    error_bound: f32,
+) !void {
+    // TODO: check for the empty list or simplify algorithm using -INF/+INF.
+    var index: usize = 0; // n.
+    var minimum = uncompressed_values[0]; // m.
+    var maximum = uncompressed_values[0]; // M.
+
+    for (uncompressed_values) |value| {
+        if ((@max(value, maximum) - @min(value, minimum)) > 2 * error_bound) {
+            const compressed_value = (maximum + minimum) / 2;
+            try appendValueAndIndexToArrayList(compressed_value, index, compressed_values);
+            minimum = value;
+            maximum = value;
+        } else {
+            minimum = @min(value, minimum);
+            maximum = @max(value, maximum);
+        }
+        index += 1;
+    }
+
+    const compressed_value = (maximum + minimum) / 2;
+    try appendValueAndIndexToArrayList(compressed_value, index, compressed_values);
+}
+
+fn appendValueAndIndexToArrayList(
+    value: f64,
+    index: usize,
+    compressed_values: *ArrayList(u8),
+) !void {
+    const valueAsBytes: [8]u8 = @bitCast(value);
+    try compressed_values.appendSlice(valueAsBytes[0..]);
+    const indexAsBytes: [8]u8 = @bitCast(index); // No -1 due to 0 indexing.
+    try compressed_values.appendSlice(indexAsBytes[0..]);
+}
+
+pub fn poorMansCompressionDecompress(
+    compressed_values: []const u8,
+    decompressed_values: *ArrayList(f64),
+) error{OutOfMemory}!void {
+    // TODO: Check length of uncompressed_values is modulo 16.
+    const compressed_values_and_index = mem.bytesAsSlice(
+        f64,
+        compressed_values,
+    );
+
+    var compressed_index: usize = 0;
+    var uncompressed_index: usize = 0;
+    while (compressed_index < compressed_values_and_index.len) : (compressed_index += 2) {
+        const value = compressed_values_and_index[compressed_index];
+        const index: usize = @bitCast(compressed_values_and_index[compressed_index + 1]);
+        for (uncompressed_index..index) |_| {
+            try decompressed_values.append(value);
+        }
+        uncompressed_index = index;
+    }
+}
+
+test "PMC-MR" {
+    const alloc = testing.allocator;
+    const uncompressed_values = [_]f64{ 1.0, 2.0, 2.0, 3.0, 3.0, 3.0 };
+    var compressed_values = ArrayList(u8).init(alloc);
+    defer compressed_values.deinit();
+    var decompressed_values = ArrayList(f64).init(alloc);
+    defer decompressed_values.deinit();
+
+    try poorMansCompressionCompress(uncompressed_values[0..], &compressed_values, 0);
+    try poorMansCompressionDecompress(compressed_values.items, &decompressed_values);
+
+    try testing.expect(mem.eql(f64, uncompressed_values[0..], decompressed_values.items));
+}

--- a/src/functional/swing.zig
+++ b/src/functional/swing.zig
@@ -1,0 +1,312 @@
+// Copyright 2024 TerseTS Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file implements the Swing Filter algorithm.
+// Swing compresses a time series by removing points that
+// do not deviate significantly from a linear interpolation of their
+// neighboring points, within the error bound.
+
+const std = @import("std");
+const ts = @import("../tersets.zig");
+const testing = std.testing;
+
+pub const Segment = struct {
+    start_time: usize,
+    start_value: f64,
+    end_time: usize,
+    end_value: f64,
+};
+
+pub const Line = struct {
+    slope: f64,
+    intercept: f64,
+};
+
+fn get_line(segment: *Segment, line: *Line) !void {
+    std.debug.assert(segment.end_time != segment.start_time);
+    const duration = @as(f64, @floatFromInt(segment.end_time - segment.start_time));
+    line.slope = (segment.end_value - segment.start_value) / duration;
+    line.intercept = segment.start_value - line.slope * @as(f64, @floatFromInt(segment.start_time));
+}
+
+fn get_bound_line(segment: *Segment, line: *Line, error_bound: f32) !void {
+    std.debug.assert(segment.end_time != segment.start_time);
+    const duration = @as(f64, @floatFromInt(segment.end_time - segment.start_time));
+    line.slope = (segment.end_value + error_bound - segment.start_value) / duration;
+    line.intercept = segment.start_value - line.slope * @as(f64, @floatFromInt(segment.start_time));
+}
+
+fn printBytesAsHex(data: [*]const u8, length: usize) void {
+    std.debug.print("Hexadecimal byte values: ", .{});
+    var i: usize = 0;
+    while (i < length) : (i += 1) {
+        std.debug.print("{x} ", .{data[i]});
+    }
+    std.debug.print("\n", .{});
+}
+
+fn evaluate(line: *Line, timestamp: usize) f64 {
+    return line.slope * @as(f64, @floatFromInt(timestamp)) + line.intercept;
+}
+
+fn printArrayList(list: []const f64) void {
+    std.debug.print("\nPrint array: \n", .{});
+    for (list) |item| {
+        std.debug.print("{} ", .{item});
+    }
+    std.debug.print("\n", .{});
+}
+
+fn printLine(line: *Line, islower: bool) void {
+    if (islower) {
+        std.debug.print("lower", .{});
+    } else {
+        std.debug.print("upper", .{});
+    }
+    std.debug.print("--->line slope {} intercept {}\n", .{ line.slope, line.intercept });
+}
+
+fn printSegment(segment: *Segment) void {
+    std.debug.print("current segment: st {}, sv {}, et {}, ev {} \n", .{ segment.start_time, segment.start_value, segment.end_time, segment.end_value });
+}
+/// Applies the Swing Filter to compress a time series.
+/// @param uncompressed_values: the input time series and length
+/// @param compressed_values: the compressed representation
+/// @param error_bound: the error bound information
+/// @returns an ArrayList of compressed data points
+pub fn compress(uncompressed_values: ts.UncompressedValues, compressed_values: *ts.CompressedValues, error_bound: f32) !void {
+    const gpa = std.heap.page_allocator;
+
+    var list_values = std.ArrayList(f64).init(gpa);
+    // defer list_values.deinit();
+
+    // Initiallization
+    var upper_y: f64 = 0;
+    var lower_y: f64 = 0;
+    var tmp_upper_y: f64 = 0;
+    var tmp_lower_y: f64 = 0;
+    var upper_bound_line: Line = Line{ .slope = 0, .intercept = 0 };
+    var lower_bound_line: Line = Line{ .slope = 0, .intercept = 0 };
+    var tmp_upper_bound_line: Line = Line{ .slope = 0, .intercept = 0 };
+    var tmp_lower_bound_line: Line = Line{ .slope = 0, .intercept = 0 };
+    var current_line: Line = Line{ .slope = 0, .intercept = 0 };
+    var first_timestamp: usize = 0;
+    var current_timestamp: usize = 1;
+    var current_segment: Segment = Segment{ .start_time = first_timestamp, .start_value = uncompressed_values.data[first_timestamp], .end_time = current_timestamp, .end_value = uncompressed_values.data[current_timestamp] };
+
+    try get_bound_line(&current_segment, &upper_bound_line, error_bound);
+    try get_bound_line(&current_segment, &lower_bound_line, -error_bound);
+
+    current_timestamp += 1;
+    while (current_timestamp < uncompressed_values.len) : (current_timestamp += 1) {
+        upper_y = evaluate(&upper_bound_line, current_timestamp);
+        lower_y = evaluate(&lower_bound_line, current_timestamp);
+
+        if ((upper_y < (uncompressed_values.data[current_timestamp] - error_bound)) or
+            (lower_y > (uncompressed_values.data[current_timestamp] + error_bound)))
+        {
+            upper_y = evaluate(&upper_bound_line, current_timestamp - 1);
+            lower_y = evaluate(&lower_bound_line, current_timestamp - 1);
+            current_segment.end_value = (upper_y + lower_y) / 2;
+            try get_line(&current_segment, &current_line);
+            try list_values.append(@as(f64, @floatFromInt(current_segment.start_time)));
+            try list_values.append(current_line.slope);
+            try list_values.append(current_line.intercept);
+            first_timestamp = current_timestamp;
+            current_segment.start_time = current_timestamp;
+            current_segment.start_value = uncompressed_values.data[current_timestamp];
+            current_segment.end_time = current_timestamp + 1;
+            current_segment.end_value = uncompressed_values.data[current_timestamp + 1];
+            current_timestamp += 1;
+            try get_bound_line(&current_segment, &upper_bound_line, error_bound);
+            try get_bound_line(&current_segment, &lower_bound_line, -error_bound);
+        } else {
+            current_segment.end_time = current_timestamp;
+            current_segment.end_value = uncompressed_values.data[current_timestamp];
+            try get_bound_line(&current_segment, &tmp_upper_bound_line, error_bound);
+            try get_bound_line(&current_segment, &tmp_lower_bound_line, -error_bound);
+
+            tmp_upper_y = evaluate(&tmp_upper_bound_line, current_timestamp);
+            tmp_lower_y = evaluate(&tmp_lower_bound_line, current_timestamp);
+            if (upper_y > tmp_upper_y) {
+                upper_bound_line.slope = tmp_upper_bound_line.slope;
+                upper_bound_line.intercept = tmp_upper_bound_line.intercept;
+                upper_y = tmp_upper_y;
+            }
+            if (lower_y < tmp_lower_y) {
+                lower_bound_line.slope = tmp_lower_bound_line.slope;
+                lower_bound_line.intercept = tmp_lower_bound_line.intercept;
+                lower_y = tmp_lower_y;
+            }
+        }
+    }
+    current_segment.end_value = (upper_y + lower_y) / 2;
+    try get_line(&current_segment, &current_line);
+    try list_values.append(@as(f64, @floatFromInt(current_segment.start_time)));
+    try list_values.append(current_line.slope);
+    try list_values.append(current_line.intercept);
+    try list_values.append(@as(f64, @floatFromInt(current_timestamp)));
+    const f64_slice = list_values.items;
+    compressed_values.data = @alignCast(@ptrCast(f64_slice));
+    compressed_values.len = f64_slice.len * 8;
+}
+
+pub fn decompress(compressed_values: ts.CompressedValues, uncompressed_values: *ts.UncompressedValues) !void {
+    const gpa = std.heap.page_allocator;
+
+    var list_values = std.ArrayList(f64).init(gpa);
+    // defer list_values.deinit();
+
+    const serialized_values: [*]const f64 = @alignCast(@ptrCast(compressed_values.data));
+    const length = compressed_values.len / 8;
+
+    // const size: i32 = @as(i32, @intFromFloat(values[values.len - 1]));
+    var previous_timestamp: usize = 0;
+    var current_timestamp: usize = 0;
+    var next_timestamp: usize = 0;
+    var current_line: Line = Line{ .slope = 0, .intercept = 0 };
+
+    var index: usize = 0;
+    while (index < length - 1) : (index += 3) {
+        next_timestamp = @as(usize, @intFromFloat(serialized_values[index + 3]));
+        current_timestamp = previous_timestamp;
+        current_line.slope = serialized_values[index + 1];
+        current_line.intercept = serialized_values[index + 2];
+        while (current_timestamp < next_timestamp) : (current_timestamp += 1) {
+            const y: f64 = evaluate(&current_line, current_timestamp);
+            try list_values.append(y);
+        }
+        previous_timestamp = current_timestamp;
+    }
+
+    const f64_slice = list_values.items;
+    uncompressed_values.data = @alignCast(@ptrCast(f64_slice));
+    uncompressed_values.len = next_timestamp; //TODO: fix this
+
+}
+
+test "swing a line compress and decompress" {
+    const uncompressed_array = [_]f64{ 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5 };
+    const uncompressed_slice = uncompressed_array[0..8];
+    const uncompressed_values = ts.UncompressedValues{
+        .data = uncompressed_slice.ptr,
+        .len = uncompressed_slice.len,
+    };
+    var compressed_values = ts.CompressedValues{
+        .data = undefined,
+        .len = undefined,
+    };
+    var decompressed_values = ts.UncompressedValues{
+        .data = uncompressed_slice.ptr,
+        .len = uncompressed_slice.len,
+    };
+    const error_bound: f32 = 0.5;
+    try compress(
+        uncompressed_values,
+        &compressed_values,
+        error_bound,
+    );
+
+    // try testing.expect(compress_result == 0);
+
+    try decompress(compressed_values, &decompressed_values);
+    try testing.expectEqual(decompressed_values.len, uncompressed_values.len);
+
+    var i: usize = 0;
+    while (i < decompressed_values.len) : (i += 1) {
+        try testing.expect((uncompressed_values.data[i] + error_bound > decompressed_values.data[i]) and (uncompressed_values.data[i] - error_bound < decompressed_values.data[i]));
+    }
+}
+
+test "swing two lines compress and decompress" {
+    const uncompressed_array = [_]f64{ 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5 };
+
+    const uncompressed_slice = uncompressed_array[0..16];
+    const uncompressed_values = ts.UncompressedValues{
+        .data = uncompressed_slice.ptr,
+        .len = uncompressed_slice.len,
+    };
+    var compressed_values = ts.CompressedValues{
+        .data = undefined,
+        .len = undefined,
+    };
+    var decompressed_values = ts.UncompressedValues{
+        .data = uncompressed_slice.ptr,
+        .len = uncompressed_slice.len,
+    };
+    const error_bound: f32 = 0.5;
+    try compress(
+        uncompressed_values,
+        &compressed_values,
+        error_bound,
+    );
+
+    // try testing.expect(compress_result == 0);
+
+    try decompress(compressed_values, &decompressed_values);
+    try testing.expectEqual(uncompressed_values.len, decompressed_values.len);
+    var i: usize = 0;
+
+    i = 0;
+    while (i < decompressed_values.len) : (i += 1) {
+        try testing.expect((uncompressed_values.data[i] + error_bound > decompressed_values.data[i]) and (uncompressed_values.data[i] - error_bound < decompressed_values.data[i]));
+    }
+}
+
+test "swing multiple lines compress and decompress" {
+    var lines = [_]Line{
+        Line{ .slope = 1.0, .intercept = 2.0 },
+        Line{ .slope = -0.5, .intercept = 1.0 },
+        Line{ .slope = 0.2, .intercept = -1.5 },
+        Line{ .slope = -0.1, .intercept = 1.5 },
+    };
+    const gpa = std.heap.page_allocator;
+
+    var list_values = std.ArrayList(f64).init(gpa);
+    var i: usize = 0;
+    var index: usize = 0;
+    while (i < 1000) : (i += 1) {
+        index = i / 250;
+        try list_values.append(evaluate(&lines[index], i));
+    }
+
+    const uncompressed_slice = list_values.items;
+    const uncompressed_values = ts.UncompressedValues{
+        .data = uncompressed_slice.ptr,
+        .len = uncompressed_slice.len,
+    };
+    var compressed_values = ts.CompressedValues{
+        .data = undefined,
+        .len = undefined,
+    };
+    var decompressed_values = ts.UncompressedValues{
+        .data = uncompressed_slice.ptr,
+        .len = uncompressed_slice.len,
+    };
+    const error_bound: f32 = 0.5;
+    try compress(
+        uncompressed_values,
+        &compressed_values,
+        error_bound,
+    );
+
+    // try testing.expect(compress_result == 0);
+
+    try decompress(compressed_values, &decompressed_values);
+    try testing.expectEqual(uncompressed_values.len, decompressed_values.len);
+    i = 0;
+    while (i < decompressed_values.len) : (i += 1) {
+        try testing.expect((uncompressed_values.data[i] + error_bound > decompressed_values.data[i]) and (uncompressed_values.data[i] - error_bound < decompressed_values.data[i]));
+    }
+}

--- a/src/functional/swing.zig
+++ b/src/functional/swing.zig
@@ -12,301 +12,217 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This file implements the Swing Filter algorithm.
-// Swing compresses a time series by removing points that
-// do not deviate significantly from a linear interpolation of their
-// neighboring points, within the error bound.
+//! Implementation of Swing Filter algorithm from the paper:
+//! Hazem Elmeleegy, Ahmed K. Elmagarmid, Emmanuel Cecchet, Walid G. Aref, and Willy Zwaenepoel.
+//! Online piece-wise linear approximation of numerical streams with precision guarantees.
+//! Proc. VLDB Endow. 2, 1, 2009.
+//! https://doi.org/10.14778/1687627.1687645.
 
 const std = @import("std");
 const ts = @import("../tersets.zig");
+const utils = @import("../utils.zig");
+const print = std.debug.print;
+
+const Line = utils.Line;
+const Segment = utils.Segment;
+
+const mem = std.mem;
 const testing = std.testing;
 
-pub const Segment = struct {
-    start_time: usize,
-    start_value: f64,
-    end_time: usize,
-    end_value: f64,
-};
+const ArrayList = std.ArrayList;
 
-pub const Line = struct {
-    slope: f64,
-    intercept: f64,
-};
-
-fn get_line(segment: *Segment, line: *Line) !void {
-    std.debug.assert(segment.end_time != segment.start_time);
-    const duration = @as(f64, @floatFromInt(segment.end_time - segment.start_time));
-    line.slope = (segment.end_value - segment.start_value) / duration;
-    line.intercept = segment.start_value - line.slope * @as(f64, @floatFromInt(segment.start_time));
+fn appendLine(
+    line: *Line,
+    compressed_values: *ArrayList(u8),
+) !void {
+    const valueAsBytes: [8]u8 = @bitCast(line.slope);
+    try compressed_values.appendSlice(valueAsBytes[0..]);
+    const indexAsBytes: [8]u8 = @bitCast(line.intercept);
+    try compressed_values.appendSlice(indexAsBytes[0..]);
 }
 
-fn get_bound_line(segment: *Segment, line: *Line, error_bound: f32) !void {
-    std.debug.assert(segment.end_time != segment.start_time);
-    const duration = @as(f64, @floatFromInt(segment.end_time - segment.start_time));
-    line.slope = (segment.end_value + error_bound - segment.start_value) / duration;
-    line.intercept = segment.start_value - line.slope * @as(f64, @floatFromInt(segment.start_time));
+fn appendIndex(index: usize, compressed_values: *ArrayList(u8)) !void {
+    const indexAsFloat: [8]u8 = @bitCast(@as(f64, @floatFromInt(index)));
+    try compressed_values.appendSlice(indexAsFloat[0..]);
 }
 
-fn printBytesAsHex(data: [*]const u8, length: usize) void {
-    std.debug.print("Hexadecimal byte values: ", .{});
-    var i: usize = 0;
-    while (i < length) : (i += 1) {
-        std.debug.print("{x} ", .{data[i]});
-    }
-    std.debug.print("\n", .{});
-}
-
-fn evaluate(line: *Line, timestamp: usize) f64 {
-    return line.slope * @as(f64, @floatFromInt(timestamp)) + line.intercept;
-}
-
-fn printArrayList(list: []const f64) void {
-    std.debug.print("\nPrint array: \n", .{});
-    for (list) |item| {
-        std.debug.print("{} ", .{item});
-    }
-    std.debug.print("\n", .{});
-}
-
-fn printLine(line: *Line, islower: bool) void {
-    if (islower) {
-        std.debug.print("lower", .{});
-    } else {
-        std.debug.print("upper", .{});
-    }
-    std.debug.print("--->line slope {} intercept {}\n", .{ line.slope, line.intercept });
-}
-
-fn printSegment(segment: *Segment) void {
-    std.debug.print("current segment: st {}, sv {}, et {}, ev {} \n", .{ segment.start_time, segment.start_value, segment.end_time, segment.end_value });
-}
-/// Applies the Swing Filter to compress a time series.
 /// @param uncompressed_values: the input time series and length
 /// @param compressed_values: the compressed representation
 /// @param error_bound: the error bound information
-/// @returns an ArrayList of compressed data points
-pub fn compress(uncompressed_values: ts.UncompressedValues, compressed_values: *ts.CompressedValues, error_bound: f32) !void {
-    const gpa = std.heap.page_allocator;
-
-    var list_values = std.ArrayList(f64).init(gpa);
-    // defer list_values.deinit();
-
+pub fn compress(
+    uncompressed_values: []const f64,
+    compressed_values: *ArrayList(u8),
+    error_bound: f32,
+) !void {
     // Initiallization
     var upper_y: f64 = 0;
     var lower_y: f64 = 0;
-    var tmp_upper_y: f64 = 0;
-    var tmp_lower_y: f64 = 0;
+
     var upper_bound_line: Line = Line{ .slope = 0, .intercept = 0 };
     var lower_bound_line: Line = Line{ .slope = 0, .intercept = 0 };
-    var tmp_upper_bound_line: Line = Line{ .slope = 0, .intercept = 0 };
-    var tmp_lower_bound_line: Line = Line{ .slope = 0, .intercept = 0 };
+    var new_upper_bound_line: Line = Line{ .slope = 0, .intercept = 0 };
+    var new_lower_bound_line: Line = Line{ .slope = 0, .intercept = 0 };
     var current_line: Line = Line{ .slope = 0, .intercept = 0 };
     var first_timestamp: usize = 0;
     var current_timestamp: usize = 1;
-    var current_segment: Segment = Segment{ .start_time = first_timestamp, .start_value = uncompressed_values.data[first_timestamp], .end_time = current_timestamp, .end_value = uncompressed_values.data[current_timestamp] };
+    var current_segment: Segment = Segment{ .start_time = first_timestamp, .start_value = uncompressed_values[first_timestamp], .end_time = current_timestamp, .end_value = uncompressed_values[current_timestamp] };
 
-    try get_bound_line(&current_segment, &upper_bound_line, error_bound);
-    try get_bound_line(&current_segment, &lower_bound_line, -error_bound);
+    try utils.getBoundLine(&current_segment, &upper_bound_line, error_bound);
+    try utils.getBoundLine(&current_segment, &lower_bound_line, -error_bound);
 
     current_timestamp += 1;
     while (current_timestamp < uncompressed_values.len) : (current_timestamp += 1) {
-        upper_y = evaluate(&upper_bound_line, current_timestamp);
-        lower_y = evaluate(&lower_bound_line, current_timestamp);
-
-        if ((upper_y < (uncompressed_values.data[current_timestamp] - error_bound)) or
-            (lower_y > (uncompressed_values.data[current_timestamp] + error_bound)))
+        upper_y = utils.evaluate(&upper_bound_line, current_timestamp);
+        lower_y = utils.evaluate(&lower_bound_line, current_timestamp);
+        // The new point is outside the error bound
+        if ((upper_y < (uncompressed_values[current_timestamp] - error_bound)) or
+            (lower_y > (uncompressed_values[current_timestamp] + error_bound)))
         {
-            upper_y = evaluate(&upper_bound_line, current_timestamp - 1);
-            lower_y = evaluate(&lower_bound_line, current_timestamp - 1);
+            upper_y = utils.evaluate(&upper_bound_line, current_timestamp - 1);
+            lower_y = utils.evaluate(&lower_bound_line, current_timestamp - 1);
+
             current_segment.end_value = (upper_y + lower_y) / 2;
-            try get_line(&current_segment, &current_line);
-            try list_values.append(@as(f64, @floatFromInt(current_segment.start_time)));
-            try list_values.append(current_line.slope);
-            try list_values.append(current_line.intercept);
+
+            try utils.getLine(&current_segment, &current_line);
+            try appendLine(&current_line, compressed_values);
+            try appendIndex(current_timestamp, compressed_values);
+
+            // Update the current segment
             first_timestamp = current_timestamp;
             current_segment.start_time = current_timestamp;
-            current_segment.start_value = uncompressed_values.data[current_timestamp];
+            current_segment.start_value = uncompressed_values[current_timestamp];
             current_segment.end_time = current_timestamp + 1;
-            current_segment.end_value = uncompressed_values.data[current_timestamp + 1];
-            current_timestamp += 1;
-            try get_bound_line(&current_segment, &upper_bound_line, error_bound);
-            try get_bound_line(&current_segment, &lower_bound_line, -error_bound);
-        } else {
-            current_segment.end_time = current_timestamp;
-            current_segment.end_value = uncompressed_values.data[current_timestamp];
-            try get_bound_line(&current_segment, &tmp_upper_bound_line, error_bound);
-            try get_bound_line(&current_segment, &tmp_lower_bound_line, -error_bound);
+            current_segment.end_value = uncompressed_values[current_timestamp + 1];
 
-            tmp_upper_y = evaluate(&tmp_upper_bound_line, current_timestamp);
-            tmp_lower_y = evaluate(&tmp_lower_bound_line, current_timestamp);
+            // Recompute the upper and lower bounds
+            try utils.getBoundLine(&current_segment, &upper_bound_line, error_bound);
+            try utils.getBoundLine(&current_segment, &lower_bound_line, -error_bound);
+
+            current_timestamp += 1;
+        } // The new point is still within the error bound
+        else {
+            // Update the current segment
+            current_segment.end_time = current_timestamp;
+            current_segment.end_value = uncompressed_values[current_timestamp];
+
+            // Compute the potentially new upper and lower bounds
+            try utils.getBoundLine(&current_segment, &new_upper_bound_line, error_bound);
+            try utils.getBoundLine(&current_segment, &new_lower_bound_line, -error_bound);
+
+            const tmp_upper_y: f64 = utils.evaluate(&new_upper_bound_line, current_timestamp);
+            const tmp_lower_y: f64 = utils.evaluate(&new_lower_bound_line, current_timestamp);
+
+            // Outdate the upper and lower bounds if needed
             if (upper_y > tmp_upper_y) {
-                upper_bound_line.slope = tmp_upper_bound_line.slope;
-                upper_bound_line.intercept = tmp_upper_bound_line.intercept;
+                upper_bound_line.slope = new_upper_bound_line.slope;
+                upper_bound_line.intercept = new_upper_bound_line.intercept;
                 upper_y = tmp_upper_y;
             }
             if (lower_y < tmp_lower_y) {
-                lower_bound_line.slope = tmp_lower_bound_line.slope;
-                lower_bound_line.intercept = tmp_lower_bound_line.intercept;
+                lower_bound_line.slope = new_lower_bound_line.slope;
+                lower_bound_line.intercept = new_lower_bound_line.intercept;
                 lower_y = tmp_lower_y;
             }
         }
     }
+
     current_segment.end_value = (upper_y + lower_y) / 2;
-    try get_line(&current_segment, &current_line);
-    try list_values.append(@as(f64, @floatFromInt(current_segment.start_time)));
-    try list_values.append(current_line.slope);
-    try list_values.append(current_line.intercept);
-    try list_values.append(@as(f64, @floatFromInt(current_timestamp)));
-    const f64_slice = list_values.items;
-    compressed_values.data = @alignCast(@ptrCast(f64_slice));
-    compressed_values.len = f64_slice.len * 8;
+
+    try utils.getLine(&current_segment, &current_line);
+    try appendLine(&current_line, compressed_values);
+    try appendIndex(current_timestamp, compressed_values);
 }
 
-pub fn decompress(compressed_values: ts.CompressedValues, uncompressed_values: *ts.UncompressedValues) !void {
-    const gpa = std.heap.page_allocator;
+pub fn decompress(
+    compressed_values: []const u8,
+    decompressed_values: *ArrayList(f64),
+) error{OutOfMemory}!void {
+    // TODO: Check length of uncompressed_values is modulo 24.
 
-    var list_values = std.ArrayList(f64).init(gpa);
-    // defer list_values.deinit();
+    const compressed_lines_and_index = mem.bytesAsSlice(
+        f64,
+        compressed_values,
+    );
 
-    const serialized_values: [*]const f64 = @alignCast(@ptrCast(compressed_values.data));
-    const length = compressed_values.len / 8;
-
-    // const size: i32 = @as(i32, @intFromFloat(values[values.len - 1]));
     var previous_timestamp: usize = 0;
-    var current_timestamp: usize = 0;
-    var next_timestamp: usize = 0;
     var current_line: Line = Line{ .slope = 0, .intercept = 0 };
 
     var index: usize = 0;
-    while (index < length - 1) : (index += 3) {
-        next_timestamp = @as(usize, @intFromFloat(serialized_values[index + 3]));
-        current_timestamp = previous_timestamp;
-        current_line.slope = serialized_values[index + 1];
-        current_line.intercept = serialized_values[index + 2];
+    while (index < compressed_lines_and_index.len) : (index += 3) {
+        const next_timestamp = @as(usize, @intFromFloat(compressed_lines_and_index[index + 2]));
+        var current_timestamp = previous_timestamp;
+        current_line.slope = compressed_lines_and_index[index];
+        current_line.intercept = compressed_lines_and_index[index + 1];
         while (current_timestamp < next_timestamp) : (current_timestamp += 1) {
-            const y: f64 = evaluate(&current_line, current_timestamp);
-            try list_values.append(y);
+            const y: f64 = utils.evaluate(&current_line, current_timestamp);
+            try decompressed_values.append(y);
         }
         previous_timestamp = current_timestamp;
     }
-
-    const f64_slice = list_values.items;
-    uncompressed_values.data = @alignCast(@ptrCast(f64_slice));
-    uncompressed_values.len = next_timestamp; //TODO: fix this
-
 }
 
-test "swing a line compress and decompress" {
-    const uncompressed_array = [_]f64{ 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5 };
-    const uncompressed_slice = uncompressed_array[0..8];
-    const uncompressed_values = ts.UncompressedValues{
-        .data = uncompressed_slice.ptr,
-        .len = uncompressed_slice.len,
-    };
-    var compressed_values = ts.CompressedValues{
-        .data = undefined,
-        .len = undefined,
-    };
-    var decompressed_values = ts.UncompressedValues{
-        .data = uncompressed_slice.ptr,
-        .len = uncompressed_slice.len,
-    };
-    const error_bound: f32 = 0.5;
-    try compress(
-        uncompressed_values,
-        &compressed_values,
-        error_bound,
-    );
+test "swing single line compress and decompress" {
+    const alloc = testing.allocator;
+    const uncompressed_values = [_]f64{ 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5 };
+    var compressed_values = ArrayList(u8).init(alloc);
+    defer compressed_values.deinit();
+    var decompressed_values = ArrayList(f64).init(alloc);
+    defer decompressed_values.deinit();
 
-    // try testing.expect(compress_result == 0);
+    const error_bound: f32 = 0.0;
 
-    try decompress(compressed_values, &decompressed_values);
-    try testing.expectEqual(decompressed_values.len, uncompressed_values.len);
+    try compress(uncompressed_values[0..], &compressed_values, error_bound);
 
-    var i: usize = 0;
-    while (i < decompressed_values.len) : (i += 1) {
-        try testing.expect((uncompressed_values.data[i] + error_bound > decompressed_values.data[i]) and (uncompressed_values.data[i] - error_bound < decompressed_values.data[i]));
-    }
+    try decompress(compressed_values.items, &decompressed_values);
+
+    try testing.expect(mem.eql(f64, uncompressed_values[0..], decompressed_values.items));
 }
 
-test "swing two lines compress and decompress" {
-    const uncompressed_array = [_]f64{ 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5 };
+test "swing two parallel lines compress and decompress" {
+    const alloc = testing.allocator;
+    const uncompressed_values = [_]f64{ 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5 };
 
-    const uncompressed_slice = uncompressed_array[0..16];
-    const uncompressed_values = ts.UncompressedValues{
-        .data = uncompressed_slice.ptr,
-        .len = uncompressed_slice.len,
-    };
-    var compressed_values = ts.CompressedValues{
-        .data = undefined,
-        .len = undefined,
-    };
-    var decompressed_values = ts.UncompressedValues{
-        .data = uncompressed_slice.ptr,
-        .len = uncompressed_slice.len,
-    };
-    const error_bound: f32 = 0.5;
-    try compress(
-        uncompressed_values,
-        &compressed_values,
-        error_bound,
-    );
+    var compressed_values = ArrayList(u8).init(alloc);
+    defer compressed_values.deinit();
+    var decompressed_values = ArrayList(f64).init(alloc);
+    defer decompressed_values.deinit();
+    const error_bound: f32 = 0.0;
 
-    // try testing.expect(compress_result == 0);
+    try compress(uncompressed_values[0..], &compressed_values, error_bound);
+    try decompress(compressed_values.items, &decompressed_values);
 
-    try decompress(compressed_values, &decompressed_values);
-    try testing.expectEqual(uncompressed_values.len, decompressed_values.len);
-    var i: usize = 0;
-
-    i = 0;
-    while (i < decompressed_values.len) : (i += 1) {
-        try testing.expect((uncompressed_values.data[i] + error_bound > decompressed_values.data[i]) and (uncompressed_values.data[i] - error_bound < decompressed_values.data[i]));
-    }
+    try testing.expect(mem.eql(f64, uncompressed_values[0..], decompressed_values.items));
 }
 
-test "swing multiple lines compress and decompress" {
+test "swing 4 v-shaped lines compress and decompress" {
+    const alloc = testing.allocator;
+
     var lines = [_]Line{
-        Line{ .slope = 1.0, .intercept = 2.0 },
-        Line{ .slope = -0.5, .intercept = 1.0 },
-        Line{ .slope = 0.2, .intercept = -1.5 },
-        Line{ .slope = -0.1, .intercept = 1.5 },
+        Line{ .slope = 1, .intercept = 0.0 },
+        Line{ .slope = -1, .intercept = 50 },
+        Line{ .slope = 1, .intercept = -50 },
+        Line{ .slope = -1, .intercept = 100 },
     };
-    const gpa = std.heap.page_allocator;
 
-    var list_values = std.ArrayList(f64).init(gpa);
+    var list_values = std.ArrayList(f64).init(alloc);
+    defer list_values.deinit();
+    var compressed_values = ArrayList(u8).init(alloc);
+    defer compressed_values.deinit();
+    var decompressed_values = ArrayList(f64).init(alloc);
+    defer decompressed_values.deinit();
+    const error_bound: f32 = 0.0;
+
     var i: usize = 0;
-    var index: usize = 0;
-    while (i < 1000) : (i += 1) {
-        index = i / 250;
-        try list_values.append(evaluate(&lines[index], i));
+    var lineIndex: usize = 0;
+    while (i < 100) : (i += 1) {
+        lineIndex = i / 25;
+        try list_values.append(utils.evaluate(&lines[lineIndex], i));
     }
 
-    const uncompressed_slice = list_values.items;
-    const uncompressed_values = ts.UncompressedValues{
-        .data = uncompressed_slice.ptr,
-        .len = uncompressed_slice.len,
-    };
-    var compressed_values = ts.CompressedValues{
-        .data = undefined,
-        .len = undefined,
-    };
-    var decompressed_values = ts.UncompressedValues{
-        .data = uncompressed_slice.ptr,
-        .len = uncompressed_slice.len,
-    };
-    const error_bound: f32 = 0.5;
-    try compress(
-        uncompressed_values,
-        &compressed_values,
-        error_bound,
-    );
+    const uncompressed_values = list_values.items;
 
-    // try testing.expect(compress_result == 0);
+    try compress(uncompressed_values[0..], &compressed_values, error_bound);
+    try decompress(compressed_values.items, &decompressed_values);
 
-    try decompress(compressed_values, &decompressed_values);
-    try testing.expectEqual(uncompressed_values.len, decompressed_values.len);
-    i = 0;
-    while (i < decompressed_values.len) : (i += 1) {
-        try testing.expect((uncompressed_values.data[i] + error_bound > decompressed_values.data[i]) and (uncompressed_values.data[i] - error_bound < decompressed_values.data[i]));
-    }
+    try testing.expect(mem.eql(f64, uncompressed_values[0..], decompressed_values.items));
 }

--- a/src/functional/swing_filter.zig
+++ b/src/functional/swing_filter.zig
@@ -1,0 +1,224 @@
+// Copyright 2024 TerseTS Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Implementation of Swing Filter algorithm from the paper:
+//! Hazem Elmeleegy, Ahmed K. Elmagarmid, Emmanuel Cecchet, Walid G. Aref, and Willy Zwaenepoel.
+//! Online piece-wise linear approximation of numerical streams with precision guarantees.
+//! Proc. VLDB Endow. 2, 1, 2009.
+//! https://doi.org/10.14778/1687627.1687645.
+
+const std = @import("std");
+const ts = @import("../tersets.zig");
+const utils = @import("../utils.zig");
+const print = std.debug.print;
+
+const Line = utils.Line;
+const Segment = utils.Segment;
+
+const mem = std.mem;
+const testing = std.testing;
+
+const ArrayList = std.ArrayList;
+
+/// @param uncompressed_values: the input time series and length
+/// @param compressed_values: the compressed representation
+/// @param error_bound: the error bound information
+pub fn compress(
+    uncompressed_values: []const f64,
+    compressed_values: *ArrayList(u8),
+    error_bound: f32,
+) !void {
+    // Initiallization
+    var upper_y: f64 = 0;
+    var lower_y: f64 = 0;
+
+    var upper_bound_line: Line = Line{ .slope = 0, .intercept = 0 };
+    var lower_bound_line: Line = Line{ .slope = 0, .intercept = 0 };
+    var new_upper_bound_line: Line = Line{ .slope = 0, .intercept = 0 };
+    var new_lower_bound_line: Line = Line{ .slope = 0, .intercept = 0 };
+    var current_line: Line = Line{ .slope = 0, .intercept = 0 };
+
+    var first_timestamp: usize = 0;
+    var current_timestamp: usize = 1;
+
+    var current_segment: Segment = Segment{ .start_time = first_timestamp, .start_value = uncompressed_values[first_timestamp], .end_time = current_timestamp, .end_value = uncompressed_values[current_timestamp] };
+
+    var slope_derivate: f64 = utils.getDerivate(&current_segment); // Numerator of slope derivate to optimize Eq. (6)
+
+    try utils.getBoundLine(&current_segment, &upper_bound_line, error_bound);
+    try utils.getBoundLine(&current_segment, &lower_bound_line, -error_bound);
+
+    current_timestamp += 1;
+    while (current_timestamp < uncompressed_values.len) : (current_timestamp += 1) {
+        upper_y = utils.evaluate(&upper_bound_line, current_timestamp);
+        lower_y = utils.evaluate(&lower_bound_line, current_timestamp);
+        // Is the new point more than \epsilon above upper_y or bellow lower_y?
+        if ((upper_y < (uncompressed_values[current_timestamp] - error_bound)) or
+            (lower_y > (uncompressed_values[current_timestamp] + error_bound)))
+        { // Recording mechanism
+            const n = current_timestamp - first_timestamp;
+            const den = n * (n + 1) * (2 * n + 1) / 6;
+            const slope: f64 = @max(@min(slope_derivate / utils.usizeToF64(den), lower_bound_line.slope), upper_bound_line.slope);
+
+            try utils.getIntercept(slope, current_timestamp - 1, uncompressed_values[current_timestamp - 1], &current_line);
+            try utils.appendLine(&current_line, compressed_values);
+            try utils.appendIndex(current_timestamp, compressed_values);
+            // utils.printLine(&current_line);
+
+            // Update the current segment
+            first_timestamp = current_timestamp;
+            current_segment.start_time = current_timestamp;
+            current_segment.start_value = uncompressed_values[current_timestamp];
+            current_segment.end_time = current_timestamp + 1;
+            current_segment.end_value = uncompressed_values[current_timestamp + 1];
+
+            // Recompute the upper and lower bounds
+            try utils.getBoundLine(&current_segment, &upper_bound_line, error_bound);
+            try utils.getBoundLine(&current_segment, &lower_bound_line, -error_bound);
+
+            current_timestamp += 1; // advance the current_timestamp
+            slope_derivate = utils.getDerivate(&current_segment);
+        } else { //filtering mechanism
+            // Update the current segment
+            current_segment.end_time = current_timestamp;
+            current_segment.end_value = uncompressed_values[current_timestamp];
+
+            // Compute the potentially new upper and lower bounds
+            try utils.getBoundLine(&current_segment, &new_upper_bound_line, error_bound);
+            try utils.getBoundLine(&current_segment, &new_lower_bound_line, -error_bound);
+
+            const new_upper_y: f64 = utils.evaluate(&new_upper_bound_line, current_timestamp);
+            const new_lower_y: f64 = utils.evaluate(&new_lower_bound_line, current_timestamp);
+
+            // Outdate the upper and lower bounds if needed
+            if (upper_y > new_upper_y) { // Swing down
+                upper_bound_line.slope = new_upper_bound_line.slope;
+                upper_bound_line.intercept = new_upper_bound_line.intercept;
+                upper_y = new_upper_y;
+            }
+            if (lower_y < new_lower_y) { //Swing up
+                lower_bound_line.slope = new_lower_bound_line.slope;
+                lower_bound_line.intercept = new_lower_bound_line.intercept;
+                lower_y = new_lower_y;
+            }
+
+            // Update slope derivate
+            slope_derivate += utils.getDerivate(&current_segment);
+        }
+    }
+
+    const n = current_timestamp - first_timestamp;
+    const den = n * (n + 1) * (2 * n + 1) / 6;
+    const slope: f64 = @max(@min(slope_derivate / utils.usizeToF64(den), lower_bound_line.slope), upper_bound_line.slope);
+
+    try utils.getIntercept(slope, current_timestamp - 1, uncompressed_values[current_timestamp - 1], &current_line);
+
+    // utils.printLine(&current_line);
+    try utils.appendLine(&current_line, compressed_values);
+    try utils.appendIndex(current_timestamp, compressed_values);
+}
+
+pub fn decompress(
+    compressed_values: []const u8,
+    decompressed_values: *ArrayList(f64),
+) error{OutOfMemory}!void {
+    // TODO: Check length of uncompressed_values is modulo 24.
+
+    const compressed_lines_and_index = mem.bytesAsSlice(
+        f64,
+        compressed_values,
+    );
+
+    var previous_timestamp: usize = 0;
+    var current_line: Line = Line{ .slope = 0, .intercept = 0 };
+
+    var index: usize = 0;
+    while (index < compressed_lines_and_index.len) : (index += 3) {
+        const next_timestamp = @as(usize, @intFromFloat(compressed_lines_and_index[index + 2]));
+        var current_timestamp = previous_timestamp;
+        current_line.slope = compressed_lines_and_index[index];
+        current_line.intercept = compressed_lines_and_index[index + 1];
+        while (current_timestamp < next_timestamp) : (current_timestamp += 1) {
+            const y: f64 = utils.evaluate(&current_line, current_timestamp);
+            try decompressed_values.append(y);
+        }
+        previous_timestamp = current_timestamp;
+    }
+}
+
+test "swing-filter single line compress and decompress" {
+    const alloc = testing.allocator;
+    const uncompressed_values = [_]f64{ 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5 };
+    var compressed_values = ArrayList(u8).init(alloc);
+    defer compressed_values.deinit();
+    var decompressed_values = ArrayList(f64).init(alloc);
+    defer decompressed_values.deinit();
+
+    const error_bound: f32 = 0.0;
+
+    try compress(uncompressed_values[0..], &compressed_values, error_bound);
+
+    try decompress(compressed_values.items, &decompressed_values);
+
+    try testing.expect(mem.eql(f64, uncompressed_values[0..], decompressed_values.items));
+}
+
+test "swing-filter two parallel lines compress and decompress" {
+    const alloc = testing.allocator;
+    const uncompressed_values = [_]f64{ 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5 };
+
+    var compressed_values = ArrayList(u8).init(alloc);
+    defer compressed_values.deinit();
+    var decompressed_values = ArrayList(f64).init(alloc);
+    defer decompressed_values.deinit();
+    const error_bound: f32 = 0.0;
+
+    try compress(uncompressed_values[0..], &compressed_values, error_bound);
+    try decompress(compressed_values.items, &decompressed_values);
+
+    try testing.expect(mem.eql(f64, uncompressed_values[0..], decompressed_values.items));
+}
+
+test "swing-filter 4 v-shaped lines compress and decompress" {
+    const alloc = testing.allocator;
+
+    var lines = [_]Line{
+        Line{ .slope = 1, .intercept = 0.0 },
+        Line{ .slope = -1, .intercept = 50 },
+        Line{ .slope = 1, .intercept = -50 },
+        Line{ .slope = -1, .intercept = 100 },
+    };
+
+    var list_values = std.ArrayList(f64).init(alloc);
+    defer list_values.deinit();
+    var compressed_values = ArrayList(u8).init(alloc);
+    defer compressed_values.deinit();
+    var decompressed_values = ArrayList(f64).init(alloc);
+    defer decompressed_values.deinit();
+    const error_bound: f32 = 0.0;
+
+    var i: usize = 0;
+    var lineIndex: usize = 0;
+    while (i < 100) : (i += 1) {
+        lineIndex = i / 25;
+        try list_values.append(utils.evaluate(&lines[lineIndex], i));
+    }
+
+    const uncompressed_values = list_values.items;
+
+    try compress(uncompressed_values[0..], &compressed_values, error_bound);
+    try decompress(compressed_values.items, &decompressed_values);
+
+    try testing.expect(mem.eql(f64, uncompressed_values[0..], decompressed_values.items));
+}

--- a/src/tersets.zig
+++ b/src/tersets.zig
@@ -15,6 +15,7 @@
 //! Provides a C-API for TerseTS.
 
 const std = @import("std");
+const swing = @import("functional/swing.zig");
 const math = std.math;
 const testing = std.testing;
 
@@ -40,6 +41,12 @@ export fn compress(
             compressed_values.data = @ptrCast(uncompressed_values.data);
             compressed_values.len = uncompressed_values.len * 8;
         },
+        2 => {
+            swing.compress(uncompressed_values, compressed_values, configuration.error_bound) catch |err| {
+                std.debug.print("Caught error: {}\n", .{err});
+                return 1;
+            };
+        },
         else => return 1,
     }
 
@@ -58,6 +65,12 @@ export fn decompress(
         0 => {
             uncompressed_values.data = @alignCast(@ptrCast(compressed_values.data));
             uncompressed_values.len = compressed_values.len / 8;
+        },
+        2 => {
+            swing.decompress(compressed_values, uncompressed_values) catch |err| {
+                std.debug.print("Caught error: {}\n", .{err});
+                return 1;
+            };
         },
         else => return 1,
     }

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -33,7 +33,7 @@ pub fn isWithinErrorBound(
     error_bound: f32,
 ) bool {
     for (decompressed_values, 0..) |item, i| {
-        if (!((uncompressed_values[i] < item + error_bound) and (uncompressed_values[i] > item - error_bound))) return false;
+        if (@abs(uncompressed_values[i] - item) > error_bound + 1e-7) return false;
     }
     return true;
 }
@@ -44,10 +44,14 @@ pub fn getIntercept(slope: f64, x: usize, y: f64, line: *Line) !void {
 }
 
 pub fn getLine(segment: *Segment, line: *Line) !void {
-    std.debug.assert(segment.end_time != segment.start_time);
-    const duration = @as(f64, @floatFromInt(segment.end_time - segment.start_time));
-    line.slope = (segment.end_value - segment.start_value) / duration;
-    line.intercept = segment.start_value - line.slope * @as(f64, @floatFromInt(segment.start_time));
+    if (segment.end_time != segment.start_time) {
+        const duration = @as(f64, @floatFromInt(segment.end_time - segment.start_time));
+        line.slope = (segment.end_value - segment.start_value) / duration;
+        line.intercept = segment.start_value - line.slope * @as(f64, @floatFromInt(segment.start_time));
+    } else {
+        line.slope = 0;
+        line.intercept = segment.end_value;
+    }
 }
 
 pub fn getBoundLine(segment: *Segment, line: *Line, error_bound: f32) !void {

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -1,0 +1,63 @@
+// Copyright 2024 TerseTS Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const std = @import("std");
+
+pub const Segment = struct {
+    start_time: usize,
+    start_value: f64,
+    end_time: usize,
+    end_value: f64,
+};
+
+pub const Line = struct {
+    slope: f64,
+    intercept: f64,
+};
+
+pub fn isWithinErrorBound(
+    uncompressed_values: []f64,
+    decompressed_values: []f64,
+    error_bound: f32,
+) bool {
+    for (decompressed_values, 0..) |item, i| {
+        if (!((uncompressed_values[i] < item + error_bound) and (uncompressed_values[i] > item - error_bound))) return false;
+    }
+    return true;
+}
+pub fn getLine(segment: *Segment, line: *Line) !void {
+    std.debug.assert(segment.end_time != segment.start_time);
+    const duration = @as(f64, @floatFromInt(segment.end_time - segment.start_time));
+    line.slope = (segment.end_value - segment.start_value) / duration;
+    line.intercept = segment.start_value - line.slope * @as(f64, @floatFromInt(segment.start_time));
+}
+
+pub fn getBoundLine(segment: *Segment, line: *Line, error_bound: f32) !void {
+    std.debug.assert(segment.end_time != segment.start_time);
+    const duration = @as(f64, @floatFromInt(segment.end_time - segment.start_time));
+    line.slope = (segment.end_value + error_bound - segment.start_value) / duration;
+    line.intercept = segment.start_value - line.slope * @as(f64, @floatFromInt(segment.start_time));
+}
+
+pub fn evaluate(line: *Line, timestamp: usize) f64 {
+    return line.slope * @as(f64, @floatFromInt(timestamp)) + line.intercept;
+}
+
+pub fn printLine(line: *Line) void {
+    std.debug.print("Line: slope {} intercept {}\n", .{ line.slope, line.intercept });
+}
+
+pub fn printSegment(segment: *Segment) void {
+    std.debug.print("Segment: st {}, sv {}, et {}, ev {} \n", .{ segment.start_time, segment.start_value, segment.end_time, segment.end_value });
+}


### PR DESCRIPTION
In this PR, the algorithm swing-filter [1] is implemented. Moreover, a version of it called swing-mid-range has also been implemented. The main difference is that swing-filter minimizes the square error between the approximation line and the uncompressed values. Instead, swing-mid-range only finds the line that crosses the middle point of the upper and lower bounds lines. This PR contains several tests for both algorithms. The PR contains code from Poor's Man Compression to be able to run properly.  

[1]Hazem Elmeleegy, Ahmed K. Elmagarmid, Emmanuel Cecchet, Walid G. Aref, and Willy Zwaenepoel. Online piece-wise linear approximation of numerical streams with precision guarantees. Proc. VLDB Endow. 2, 1, 2009. https://doi.org/10.14778/1687627.1687645.