### PR TITLE
Clean interface and add Poor Man's Compression

### DIFF
--- a/.github/workflows/zig-build-lint-and-test-on-pr-and-push.yml
+++ b/.github/workflows/zig-build-lint-and-test-on-pr-and-push.yml
@@ -28,11 +28,14 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        operating-system: [ubuntu-latest, macos-latest, windows-latest]
+        # macos-13 is used instead of macos-latest as Zig compiles to x86_64 on mac
+        operating-system: [ubuntu-latest, macos-13, windows-latest]
 
     steps:
     - uses: actions/checkout@v4
     - uses: goto-bus-stop/setup-zig@v2
+      with:
+        version: 0.12.0  # Use a stable Zig version
 
     - name: Zig Build Debug
       run: zig build -Doptimize=Debug
@@ -50,9 +53,6 @@ jobs:
       run: gcc -Wall -Wextra tersets.h
       working-directory: bindings/c
 
-    - name: Python Install Package
-      run: python3 -m pip install .
-      working-directory: bindings/python
     - name: Python Run unittest
       run: python3 -m unittest --verbose
       working-directory: bindings/python

--- a/build.zig
+++ b/build.zig
@@ -17,7 +17,7 @@ const std = @import("std");
 pub fn build(b: *std.Build) void {
 
     // Configuration.
-    const path = "src/tersets.zig";
+    const path = "src/capi.zig";
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
     const options = .{

--- a/src/capi.zig
+++ b/src/capi.zig
@@ -133,10 +133,30 @@ test "error for unknown compression method" {
     try testing.expectEqual(return_code, 1);
 }
 
+test "error for empty input when compressing" {
+    const uncompressed_values = UncompressedValues{
+        .data = undefined,
+        .len = 0,
+    };
+    var compressed_values = CompressedValues{
+        .data = undefined,
+        .len = undefined,
+    };
+    const configuration = Configuration{ .method = 0, .error_bound = 0 };
+
+    const return_code = compress(
+        uncompressed_values,
+        &compressed_values,
+        configuration,
+    );
+
+    try testing.expectEqual(return_code, 2);
+}
+
 test "error for negative error bound when compressing" {
     const uncompressed_values = UncompressedValues{
         .data = undefined,
-        .len = undefined,
+        .len = 1, // If undefined an empty input error is returned.
     };
     var compressed_values = CompressedValues{
         .data = undefined,
@@ -150,7 +170,7 @@ test "error for negative error bound when compressing" {
         configuration,
     );
 
-    try testing.expectEqual(return_code, 2);
+    try testing.expectEqual(return_code, 3);
 }
 
 test "error for unknown decompression method" {
@@ -174,16 +194,16 @@ test "error for unknown decompression method" {
     try testing.expectEqual(return_code, 1);
 }
 
-test "error for negative error bound when decompressing" {
+test "error for empty input when decompressing" {
     const compressed_values = CompressedValues{
         .data = undefined,
-        .len = undefined,
+        .len = 0,
     };
     var decompressed_values = UncompressedValues{
         .data = undefined,
         .len = undefined,
     };
-    const configuration = Configuration{ .method = 0, .error_bound = -1 };
+    const configuration = Configuration{ .method = 0, .error_bound = 0 };
 
     const return_code = decompress(
         compressed_values,

--- a/src/capi.zig
+++ b/src/capi.zig
@@ -1,0 +1,220 @@
+// Copyright 2024 TerseTS Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides a C-API for TerseTS.
+
+const std = @import("std");
+const math = std.math;
+const ArrayList = std.ArrayList;
+const testing = std.testing;
+
+const tersets = @import("tersets.zig");
+
+/// Global memory allocator used by tersets.
+var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+const allocator = gpa.allocator();
+
+/// A pointer to uncompressed values and the number of values.
+pub const UncompressedValues = Array(f64);
+
+/// A pointer to compressed values and the number of bytes.
+pub const CompressedValues = Array(u8);
+
+/// Configuration to use for compression and/or decompression.
+pub const Configuration = extern struct { method: u8, error_bound: f32 };
+
+/// Compress `uncompressed_values` to `compressed_values` according to `configuration`.
+/// On success zero is returned, and the following non-zero values are returned on errors:
+/// - 1) Unsupported compression method.
+/// - 2) Error bound is negative.
+/// - 3) No memory for decompressed values.
+export fn compress(
+    uncompressed_values_array: UncompressedValues,
+    compressed_values_array: *CompressedValues,
+    configuration: Configuration,
+) i32 {
+    const uncompressed_values = uncompressed_values_array.data[0..uncompressed_values_array.len];
+    var compressed_values = ArrayList(u8).init(allocator);
+    if (configuration.method > 0) return 1; // Check if larger than the largest int used by Method.
+    const method: tersets.Method = @enumFromInt(configuration.method);
+    if (configuration.error_bound < 0) return 2;
+
+    tersets.compress(
+        uncompressed_values,
+        &compressed_values,
+        method,
+        configuration.error_bound,
+    ) catch return 3;
+
+    compressed_values_array.data = compressed_values.items.ptr;
+    compressed_values_array.len = compressed_values.items.len;
+
+    return 0;
+}
+
+/// Decompress `compressed_values` to `uncompressed_values` according to `configuration`.
+/// On success zero is returned, and the following non-zero values are returned on errors:
+/// - 1) Unsupported decompression method.
+/// - 2) Error bound is negative.
+/// - 3) No memory for decompressed values.
+export fn decompress(
+    compressed_values_array: CompressedValues,
+    decompressed_values_array: *UncompressedValues,
+    configuration: Configuration,
+) i32 {
+    const compressed_values = compressed_values_array.data[0..compressed_values_array.len];
+    var decompressed_values = ArrayList(f64).init(allocator);
+    if (configuration.method > 0) return 1; // Check if larger than the largest int used by Method.
+    const method: tersets.Method = @enumFromInt(configuration.method);
+    if (configuration.error_bound < 0) return 2; // Check is included for consistency with compress.
+
+    tersets.decompress(compressed_values, &decompressed_values, method) catch return 3;
+
+    decompressed_values_array.data = decompressed_values.items.ptr;
+    decompressed_values_array.len = decompressed_values.items.len;
+
+    return 0;
+}
+
+/// `Array` is a pointer to values of type `data_type` and the number of values.
+fn Array(comptime data_type: type) type {
+    return extern struct { data: [*]const data_type, len: usize };
+}
+
+test "method enum must match method constants" {
+    try testing.expectEqual(@intFromEnum(tersets.Method.PoorMansCompressionMidrange), 0);
+}
+
+test "error for unknown compression method" {
+    const uncompressed_values = UncompressedValues{
+        .data = undefined,
+        .len = undefined,
+    };
+    var compressed_values = CompressedValues{
+        .data = undefined,
+        .len = undefined,
+    };
+    var configuration = Configuration{ .method = 0, .error_bound = 0 };
+    configuration.method = math.maxInt(@TypeOf(configuration.method));
+
+    const result = compress(
+        uncompressed_values,
+        &compressed_values,
+        configuration,
+    );
+
+    try testing.expectEqual(result, 1);
+}
+
+test "error for negative error bound when compressing" {
+    const uncompressed_values = UncompressedValues{
+        .data = undefined,
+        .len = undefined,
+    };
+    var compressed_values = CompressedValues{
+        .data = undefined,
+        .len = undefined,
+    };
+    const configuration = Configuration{ .method = 0, .error_bound = -1 };
+
+    const result = compress(
+        uncompressed_values,
+        &compressed_values,
+        configuration,
+    );
+
+    try testing.expectEqual(result, 2);
+}
+
+test "error for unknown decompression method" {
+    const compressed_values = CompressedValues{
+        .data = undefined,
+        .len = undefined,
+    };
+    var decompressed_values = UncompressedValues{
+        .data = undefined,
+        .len = undefined,
+    };
+    var configuration = Configuration{ .method = 0, .error_bound = 0 };
+    configuration.method = math.maxInt(@TypeOf(configuration.method));
+
+    const result = decompress(
+        compressed_values,
+        &decompressed_values,
+        configuration,
+    );
+
+    try testing.expectEqual(result, 1);
+}
+
+test "error for negative error bound when decompressing" {
+    const compressed_values = CompressedValues{
+        .data = undefined,
+        .len = undefined,
+    };
+    var decompressed_values = UncompressedValues{
+        .data = undefined,
+        .len = undefined,
+    };
+    const configuration = Configuration{ .method = 0, .error_bound = -1 };
+
+    const result = decompress(
+        compressed_values,
+        &decompressed_values,
+        configuration,
+    );
+
+    try testing.expectEqual(result, 2);
+}
+
+test "can compress and decompress" {
+    const uncompressed_array = [_]f64{ 0.1, 1.1, 1.9, 2.5, 3.8 };
+    const uncompressed_values = UncompressedValues{
+        .data = &uncompressed_array,
+        .len = uncompressed_array.len,
+    };
+    var compressed_values = CompressedValues{
+        .data = undefined,
+        .len = undefined,
+    };
+    var decompressed_values = UncompressedValues{
+        .data = &uncompressed_array,
+        .len = uncompressed_array.len,
+    };
+    const configuration = Configuration{ .method = 0, .error_bound = 0 };
+
+    const compress_code = compress(
+        uncompressed_values,
+        &compressed_values,
+        configuration,
+    );
+    try testing.expect(compress_code == 0);
+
+    const decompress_code = decompress(
+        compressed_values,
+        &decompressed_values,
+        configuration,
+    );
+    try testing.expect(decompress_code == 0);
+
+    try testing.expectEqual(decompressed_values.len, uncompressed_values.len);
+
+    var i: usize = 0;
+    while (i < decompressed_values.len) : (i += 1) {
+        try testing.expectEqual(
+            decompressed_values.data[i],
+            uncompressed_values.data[i],
+        );
+    }
+}

--- a/src/capi.zig
+++ b/src/capi.zig
@@ -109,6 +109,7 @@ fn errorToInt(err: Error) i32 {
 
 test "method enum must match method constants" {
     try testing.expectEqual(@intFromEnum(tersets.Method.PoorMansCompressionMidrange), 0);
+    try testing.expectEqual(@intFromEnum(tersets.Method.PoorMansCompressionMean), 1);
 }
 
 test "error for unknown compression method" {

--- a/src/capi.zig
+++ b/src/capi.zig
@@ -48,7 +48,7 @@ export fn compress(
 ) i32 {
     const uncompressed_values = uncompressed_values_array.data[0..uncompressed_values_array.len];
     var compressed_values = ArrayList(u8).init(allocator);
-    if (configuration.method > 0) return 1; // Check if larger than the largest int used by Method.
+    if (configuration.method > 1) return 1; // Check if larger than the largest int used by Method.
     const method: tersets.Method = @enumFromInt(configuration.method);
 
     tersets.compress(
@@ -77,7 +77,7 @@ export fn decompress(
 ) i32 {
     const compressed_values = compressed_values_array.data[0..compressed_values_array.len];
     var decompressed_values = ArrayList(f64).init(allocator);
-    if (configuration.method > 0) return 1; // Check if larger than the largest int used by Method.
+    if (configuration.method > 1) return 1; // Check if larger than the largest int used by Method.
     const method: tersets.Method = @enumFromInt(configuration.method);
 
     tersets.decompress(

--- a/src/functional/poor_mans_compression.zig
+++ b/src/functional/poor_mans_compression.zig
@@ -1,0 +1,99 @@
+// Copyright 2024 TerseTS Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Implementation of "Poor Man’s Compression - Midrange" and "Poor Man’s
+//! Compression - Mean" from the paper "Iosif Lazaridis, Sharad Mehrotra:
+//! Capturing Sensor-Generated Time Series with Quality Guarantees. ICDE 2003:
+//! 429-440".
+
+const std = @import("std");
+const math = std.math;
+const mem = std.mem;
+const testing = std.testing;
+
+const ArrayList = std.ArrayList;
+
+pub fn poorMansCompressionCompress(
+    uncompressed_values: []const f64,
+    compressed_values: *ArrayList(u8),
+    error_bound: f32,
+) !void {
+    // TODO: check for the empty list or simplify algorithm using -INF/+INF.
+    var index: usize = 0; // n.
+    var minimum = uncompressed_values[0]; // m.
+    var maximum = uncompressed_values[0]; // M.
+
+    for (uncompressed_values) |value| {
+        if ((@max(value, maximum) - @min(value, minimum)) > 2 * error_bound) {
+            const compressed_value = (maximum + minimum) / 2;
+            try appendValueAndIndexToArrayList(compressed_value, index, compressed_values);
+            minimum = value;
+            maximum = value;
+        } else {
+            minimum = @min(value, minimum);
+            maximum = @max(value, maximum);
+        }
+        index += 1;
+    }
+
+    const compressed_value = (maximum + minimum) / 2;
+    try appendValueAndIndexToArrayList(compressed_value, index, compressed_values);
+}
+
+fn appendValueAndIndexToArrayList(
+    value: f64,
+    index: usize,
+    compressed_values: *ArrayList(u8),
+) !void {
+    const valueAsBytes: [8]u8 = @bitCast(value);
+    try compressed_values.appendSlice(valueAsBytes[0..]);
+    const indexAsBytes: [8]u8 = @bitCast(index); // No -1 due to 0 indexing.
+    try compressed_values.appendSlice(indexAsBytes[0..]);
+}
+
+pub fn poorMansCompressionDecompress(
+    compressed_values: []const u8,
+    decompressed_values: *ArrayList(f64),
+) error{OutOfMemory}!void {
+    // TODO: Check length of uncompressed_values is modulo 16.
+    const compressed_values_and_index = mem.bytesAsSlice(
+        f64,
+        compressed_values,
+    );
+
+    var compressed_index: usize = 0;
+    var uncompressed_index: usize = 0;
+    while (compressed_index < compressed_values_and_index.len) : (compressed_index += 2) {
+        const value = compressed_values_and_index[compressed_index];
+        const index: usize = @bitCast(compressed_values_and_index[compressed_index + 1]);
+        for (uncompressed_index..index) |_| {
+            try decompressed_values.append(value);
+        }
+        uncompressed_index = index;
+    }
+}
+
+test "PMC-MR" {
+    const alloc = testing.allocator;
+    const uncompressed_values = [_]f64{ 1.0, 2.0, 2.0, 3.0, 3.0, 3.0 };
+    var compressed_values = ArrayList(u8).init(alloc);
+    defer compressed_values.deinit();
+    var decompressed_values = ArrayList(f64).init(alloc);
+    defer decompressed_values.deinit();
+
+    try poorMansCompressionCompress(uncompressed_values[0..], &compressed_values, 0);
+    try poorMansCompressionDecompress(compressed_values.items, &decompressed_values);
+
+    try testing.expect(mem.eql(f64, uncompressed_values[0..], decompressed_values.items));
+}

--- a/src/functional/poor_mans_compression_midrange.zig
+++ b/src/functional/poor_mans_compression_midrange.zig
@@ -24,7 +24,7 @@ const testing = std.testing;
 
 const ArrayList = std.ArrayList;
 
-pub fn poorMansCompressionCompress(
+pub fn compress(
     uncompressed_values: []const f64,
     compressed_values: *ArrayList(u8),
     error_bound: f32,
@@ -62,7 +62,7 @@ fn appendValueAndIndexToArrayList(
     try compressed_values.appendSlice(indexAsBytes[0..]);
 }
 
-pub fn poorMansCompressionDecompress(
+pub fn decompress(
     compressed_values: []const u8,
     decompressed_values: *ArrayList(f64),
 ) error{OutOfMemory}!void {
@@ -92,8 +92,8 @@ test "PMC-MR" {
     var decompressed_values = ArrayList(f64).init(alloc);
     defer decompressed_values.deinit();
 
-    try poorMansCompressionCompress(uncompressed_values[0..], &compressed_values, 0);
-    try poorMansCompressionDecompress(compressed_values.items, &decompressed_values);
+    try compress(uncompressed_values[0..], &compressed_values, 0);
+    try decompress(compressed_values.items, &decompressed_values);
 
     try testing.expect(mem.eql(f64, uncompressed_values[0..], decompressed_values.items));
 }

--- a/src/functional/poor_mans_compression_midrange.zig
+++ b/src/functional/poor_mans_compression_midrange.zig
@@ -21,15 +21,18 @@ const std = @import("std");
 const math = std.math;
 const mem = std.mem;
 const testing = std.testing;
-
 const ArrayList = std.ArrayList;
 
+const tersets = @import("../tersets.zig");
+const Error = tersets.Error;
+
+/// Compress `uncompressed_values` within `error_bound` using "Poor Man’s Compression - Midrange"
+/// and write the result to `compressed_values`. If an error occurs it is returned.
 pub fn compress(
     uncompressed_values: []const f64,
     compressed_values: *ArrayList(u8),
     error_bound: f32,
-) !void {
-    // TODO: check for the empty list or simplify algorithm using -INF/+INF.
+) Error!void {
     var index: usize = 0; // n.
     var minimum = uncompressed_values[0]; // m.
     var maximum = uncompressed_values[0]; // M.
@@ -62,15 +65,16 @@ fn appendValueAndIndexToArrayList(
     try compressed_values.appendSlice(indexAsBytes[0..]);
 }
 
+/// Decompress `compressed_values` using "Poor Man’s Compression - Midrange" and write the result
+/// to `decompressed_values`. If an error occurs it is returned.
 pub fn decompress(
     compressed_values: []const u8,
     decompressed_values: *ArrayList(f64),
-) error{OutOfMemory}!void {
-    // TODO: Check length of uncompressed_values is modulo 16.
-    const compressed_values_and_index = mem.bytesAsSlice(
-        f64,
-        compressed_values,
-    );
+) Error!void {
+    // The compressed representation is pairs containing a 64-bit float value and 64-bit end index.
+    if (compressed_values.len % 16 != 0) return Error.IncorrectInput;
+
+    const compressed_values_and_index = mem.bytesAsSlice(f64, compressed_values);
 
     var compressed_index: usize = 0;
     var uncompressed_index: usize = 0;

--- a/src/functional/poor_mans_compression_midrange.zig
+++ b/src/functional/poor_mans_compression_midrange.zig
@@ -34,8 +34,8 @@ pub fn compress(
     error_bound: f32,
 ) Error!void {
     var index: usize = 0; // n.
-    var minimum = uncompressed_values[0]; // m.
-    var maximum = uncompressed_values[0]; // M.
+    var minimum: f80 = uncompressed_values[0]; // m.
+    var maximum: f80 = uncompressed_values[0]; // M.
 
     for (uncompressed_values) |value| {
         if ((@max(value, maximum) - @min(value, minimum)) > 2 * error_bound) {
@@ -55,10 +55,11 @@ pub fn compress(
 }
 
 fn appendValueAndIndexToArrayList(
-    value: f64,
+    compressed_value: f80,
     index: usize,
     compressed_values: *ArrayList(u8),
 ) !void {
+    const value: f64 = @floatCast(compressed_value);
     const valueAsBytes: [8]u8 = @bitCast(value);
     try compressed_values.appendSlice(valueAsBytes[0..]);
     const indexAsBytes: [8]u8 = @bitCast(index); // No -1 due to 0 indexing.

--- a/src/tersets.zig
+++ b/src/tersets.zig
@@ -12,175 +12,44 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Provides a C-API for TerseTS.
+//! Provides a Zig API for TerseTS.
 
 const std = @import("std");
-const math = std.math;
+const Allocator = std.mem.Allocator;
 const ArrayList = std.ArrayList;
-const testing = std.testing;
 
-const pmc = @import("functional/poor_mans_compression.zig");
+const pmc_mr = @import("functional/poor_mans_compression_midrange.zig");
 
-/// Global memory allocator used by tersets.
-var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-const alloc = gpa.allocator();
+/// The compression methods.
+pub const Method = enum {
+    PoorMansCompressionMidrange,
+};
 
-/// A pointer to uncompressed values and the number of values.
-pub const UncompressedValues = Array(f64);
-
-/// A pointer to compressed values and the number of bytes.
-pub const CompressedValues = Array(u8);
-
-/// Configuration to use for compression and/or decompression.
-pub const Configuration = extern struct { method: u8, error_bound: f32 };
-
-/// Compress `uncompressed_values` to `compressed_values` according to
-/// `configuration`. The following non-zero values are returned on errors:
-/// - 1) Unsupported compression method.
-export fn compress(
-    uncompressed_values: UncompressedValues,
-    compressed_values: *CompressedValues,
-    configuration: Configuration,
-) i32 {
-    switch (configuration.method) {
-        0 => {
-            // TODO: split compress into compress_zig with slice and ArrayList
-            // as input and compress_c so C->Zig and Zig-C is implemented once.
-            const uncompressed_values_slice = uncompressed_values.data[0..uncompressed_values.len];
-            var compressed_values_array_list = ArrayList(u8).init(alloc);
-            pmc.poorMansCompressionCompress(
-                uncompressed_values_slice,
-                &compressed_values_array_list,
-                configuration.error_bound,
-            ) catch {}; // TODO: remove export and return errors to C function
-            // https://github.com/Vexu/bog/blob/master/src/lib.zig
-            // https://github.com/Vexu/bog/blob/master/include/bog.h
-            compressed_values.data = compressed_values_array_list.items.ptr;
-            compressed_values.len = compressed_values_array_list.items.len;
+/// Compress `uncompressed_values` within `error_bound` using `method` and write the result to
+/// `compressed_values`. If an error occurs it is returned.
+pub fn compress(
+    uncompressed_values: []const f64,
+    compressed_values: *ArrayList(u8),
+    method: Method,
+    error_bound: f32,
+) !void {
+    switch (method) {
+        .PoorMansCompressionMidrange => {
+            try pmc_mr.compress(uncompressed_values, compressed_values, error_bound);
         },
-        else => return 1,
     }
-
-    return 0;
 }
 
-/// Decompress `compressed_values` to `uncompressed_values` according to
-/// `configuration`. The following non-zero values are returned on errors:
-/// - 1) Unsupported decompression method.
-export fn decompress(
-    compressed_values: CompressedValues,
-    decompressed_values: *UncompressedValues,
-    configuration: Configuration,
-) i32 {
-    switch (configuration.method) {
-        0 => {
-            // TODO: split compress into compress_zig with slice and ArrayList
-            // as input and compress_c so C->Zig and Zig-C is implemented once.
-            const compressed_values_slice = compressed_values.data[0..compressed_values.len];
-            var decompressed_values_array_list = ArrayList(f64).init(alloc);
-            pmc.poorMansCompressionDecompress(
-                compressed_values_slice,
-                &decompressed_values_array_list,
-            ) catch {}; // TODO: remove export and return errors to C function
-            // https://github.com/Vexu/bog/blob/master/src/lib.zig
-            // https://github.com/Vexu/bog/blob/master/include/bog.h
-            decompressed_values.data = decompressed_values_array_list.items.ptr;
-            decompressed_values.len = decompressed_values_array_list.items.len;
+/// Decompress `compressed_values` using `method` and write the result to `decompressed_values`. If
+/// an error occurs it is returned.
+pub fn decompress(
+    compressed_values: []const u8,
+    decompressed_values: *ArrayList(f64),
+    method: Method,
+) !void {
+    switch (method) {
+        .PoorMansCompressionMidrange => {
+            try pmc_mr.decompress(compressed_values, decompressed_values);
         },
-        else => return 1,
     }
-
-    return 0;
-}
-
-// TODO: Add deinit() function so bindings can deallocate returned array with
-// the compressed and decompressed data or assume they can reuse and deallocate?
-
-/// `Array` is a pointer to values of type `data_type` and the number of values.
-fn Array(comptime data_type: type) type {
-    return extern struct { data: [*]const data_type, len: usize };
-}
-
-test "compress and decompress" {
-    const uncompressed_array = [_]f64{ 0.1, 1.1, 1.9, 2.5, 3.8 };
-    const uncompressed_slice = uncompressed_array[0..5];
-    const uncompressed_values = UncompressedValues{
-        .data = uncompressed_slice.ptr,
-        .len = uncompressed_slice.len,
-    };
-    var compressed_values = CompressedValues{
-        .data = undefined,
-        .len = undefined,
-    };
-    var decompressed_values = UncompressedValues{
-        .data = uncompressed_slice.ptr,
-        .len = uncompressed_slice.len,
-    };
-    const configuration = Configuration{ .method = 0, .error_bound = 0 };
-
-    const compress_result = compress(
-        uncompressed_values,
-        &compressed_values,
-        configuration,
-    );
-    try testing.expect(compress_result == 0);
-
-    const decompress_result = decompress(
-        compressed_values,
-        &decompressed_values,
-        configuration,
-    );
-    try testing.expect(decompress_result == 0);
-
-    try testing.expectEqual(decompressed_values.len, uncompressed_values.len);
-
-    var i: usize = 0;
-    while (i < decompressed_values.len) : (i += 1) {
-        try testing.expectEqual(
-            decompressed_values.data[i],
-            uncompressed_values.data[i],
-        );
-    }
-}
-
-test "error for unknown compression method" {
-    const uncompressed_values = UncompressedValues{
-        .data = undefined,
-        .len = undefined,
-    };
-    var compressed_values = CompressedValues{
-        .data = undefined,
-        .len = undefined,
-    };
-    var configuration = Configuration{ .method = 0, .error_bound = 0 };
-    configuration.method = math.maxInt(@TypeOf(configuration.method));
-
-    const result = compress(
-        uncompressed_values,
-        &compressed_values,
-        configuration,
-    );
-
-    try testing.expectEqual(result, 1);
-}
-
-test "error for unknown decompression method" {
-    const compressed_values = CompressedValues{
-        .data = undefined,
-        .len = undefined,
-    };
-    var uncompressed_values = UncompressedValues{
-        .data = undefined,
-        .len = undefined,
-    };
-    var configuration = Configuration{ .method = 0, .error_bound = 0 };
-    configuration.method = math.maxInt(@TypeOf(configuration.method));
-
-    const result = decompress(
-        compressed_values,
-        &uncompressed_values,
-        configuration,
-    );
-
-    try testing.expectEqual(result, 1);
 }

--- a/src/tersets.zig
+++ b/src/tersets.zig
@@ -18,7 +18,7 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 const ArrayList = std.ArrayList;
 
-const pmc_mr = @import("functional/poor_mans_compression_midrange.zig");
+const pmc = @import("functional/poor_mans_compression.zig");
 
 /// The errors that can occur in TerseTS.
 pub const Error = error{
@@ -31,6 +31,7 @@ pub const Error = error{
 /// The compression methods in TerseTS.
 pub const Method = enum {
     PoorMansCompressionMidrange,
+    PoorMansCompressionMean,
 };
 
 /// Compress `uncompressed_values` within `error_bound` using `method` and write the result to
@@ -45,8 +46,8 @@ pub fn compress(
     if (error_bound < 0) return Error.NegativeErrorBound;
 
     switch (method) {
-        .PoorMansCompressionMidrange => {
-            try pmc_mr.compress(uncompressed_values, compressed_values, error_bound);
+        .PoorMansCompressionMidrange, .PoorMansCompressionMean => {
+            try pmc.compress_midrange(uncompressed_values, compressed_values, error_bound);
         },
     }
 }
@@ -62,7 +63,10 @@ pub fn decompress(
 
     switch (method) {
         .PoorMansCompressionMidrange => {
-            try pmc_mr.decompress(compressed_values, decompressed_values);
+            try pmc.decompress(compressed_values, decompressed_values);
+        },
+        .PoorMansCompressionMean => {
+            try pmc.decompress(compressed_values, decompressed_values);
         },
     }
 }

--- a/src/tersets.zig
+++ b/src/tersets.zig
@@ -16,7 +16,14 @@
 
 const std = @import("std");
 const math = std.math;
+const ArrayList = std.ArrayList;
 const testing = std.testing;
+
+const pmc = @import("functional/poor_mans_compression.zig");
+
+/// Global memory allocator used by tersets.
+var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+const alloc = gpa.allocator();
 
 /// A pointer to uncompressed values and the number of values.
 pub const UncompressedValues = Array(f64);
@@ -37,8 +44,19 @@ export fn compress(
 ) i32 {
     switch (configuration.method) {
         0 => {
-            compressed_values.data = @ptrCast(uncompressed_values.data);
-            compressed_values.len = uncompressed_values.len * 8;
+            // TODO: split compress into compress_zig with slice and ArrayList
+            // as input and compress_c so C->Zig and Zig-C is implemented once.
+            const uncompressed_values_slice = uncompressed_values.data[0..uncompressed_values.len];
+            var compressed_values_array_list = ArrayList(u8).init(alloc);
+            pmc.poorMansCompressionCompress(
+                uncompressed_values_slice,
+                &compressed_values_array_list,
+                configuration.error_bound,
+            ) catch {}; // TODO: remove export and return errors to C function
+            // https://github.com/Vexu/bog/blob/master/src/lib.zig
+            // https://github.com/Vexu/bog/blob/master/include/bog.h
+            compressed_values.data = compressed_values_array_list.items.ptr;
+            compressed_values.len = compressed_values_array_list.items.len;
         },
         else => return 1,
     }
@@ -51,19 +69,32 @@ export fn compress(
 /// - 1) Unsupported decompression method.
 export fn decompress(
     compressed_values: CompressedValues,
-    uncompressed_values: *UncompressedValues,
+    decompressed_values: *UncompressedValues,
     configuration: Configuration,
 ) i32 {
     switch (configuration.method) {
         0 => {
-            uncompressed_values.data = @alignCast(@ptrCast(compressed_values.data));
-            uncompressed_values.len = compressed_values.len / 8;
+            // TODO: split compress into compress_zig with slice and ArrayList
+            // as input and compress_c so C->Zig and Zig-C is implemented once.
+            const compressed_values_slice = compressed_values.data[0..compressed_values.len];
+            var decompressed_values_array_list = ArrayList(f64).init(alloc);
+            pmc.poorMansCompressionDecompress(
+                compressed_values_slice,
+                &decompressed_values_array_list,
+            ) catch {}; // TODO: remove export and return errors to C function
+            // https://github.com/Vexu/bog/blob/master/src/lib.zig
+            // https://github.com/Vexu/bog/blob/master/include/bog.h
+            decompressed_values.data = decompressed_values_array_list.items.ptr;
+            decompressed_values.len = decompressed_values_array_list.items.len;
         },
         else => return 1,
     }
 
     return 0;
 }
+
+// TODO: Add deinit() function so bindings can deallocate returned array with
+// the compressed and decompressed data or assume they can reuse and deallocate?
 
 /// `Array` is a pointer to values of type `data_type` and the number of values.
 fn Array(comptime data_type: type) type {

--- a/src/tersets.zig
+++ b/src/tersets.zig
@@ -20,7 +20,15 @@ const ArrayList = std.ArrayList;
 
 const pmc_mr = @import("functional/poor_mans_compression_midrange.zig");
 
-/// The compression methods.
+/// The errors that can occur in TerseTS.
+pub const Error = error{
+    EmptyInput,
+    IncorrectInput,
+    NegativeErrorBound,
+    OutOfMemory,
+};
+
+/// The compression methods in TerseTS.
 pub const Method = enum {
     PoorMansCompressionMidrange,
 };
@@ -32,7 +40,10 @@ pub fn compress(
     compressed_values: *ArrayList(u8),
     method: Method,
     error_bound: f32,
-) !void {
+) Error!void {
+    if (uncompressed_values.len == 0) return Error.EmptyInput;
+    if (error_bound < 0) return Error.NegativeErrorBound;
+
     switch (method) {
         .PoorMansCompressionMidrange => {
             try pmc_mr.compress(uncompressed_values, compressed_values, error_bound);
@@ -46,7 +57,9 @@ pub fn decompress(
     compressed_values: []const u8,
     decompressed_values: *ArrayList(f64),
     method: Method,
-) !void {
+) Error!void {
+    if (compressed_values.len == 0) return Error.EmptyInput;
+
     switch (method) {
         .PoorMansCompressionMidrange => {
             try pmc_mr.decompress(compressed_values, decompressed_values);


### PR DESCRIPTION
This PR simplify the implementation of the interface by splitting it into `src/tersets.zig` for the Zig API and `src/capi.zig` for the C API. Thus, `src/tersets.zig` implements all of the functionality for executing the correct method while `src/capi.zig` implements all of the functionality for using TerseTS through C. These changes where made while implementing Poor Man's Compression Midrange and Poor Man's Compression Mean which is also included in this PR. Both Midrange and Mean is implemented in `src/functional/poor_mans_compression.zig` as their only difference is the compression method, so implementing them in different files would either require a lot of duplicate code or require a separate file with the bulk of the code and two files containing only the compression methods. The testing of the two methods is purposely not exhaustive as Property Based Testing is planned.