### PR TITLE
Add convex hull primitives

### DIFF
--- a/src/capi.zig
+++ b/src/capi.zig
@@ -122,7 +122,6 @@ fn errorToInt(err: Error) i32 {
         Error.NegativeErrorBound => return 3,
         Error.IncorrectInput => return 4,
         Error.OutOfMemory => return 5,
-        Error.EmptySet => return 6,
     }
 }
 

--- a/src/capi.zig
+++ b/src/capi.zig
@@ -122,6 +122,7 @@ fn errorToInt(err: Error) i32 {
         Error.NegativeErrorBound => return 3,
         Error.IncorrectInput => return 4,
         Error.OutOfMemory => return 5,
+        Error.EmptySet => return 6,
     }
 }
 

--- a/src/functional/geometry/convex_hull.zig
+++ b/src/functional/geometry/convex_hull.zig
@@ -130,114 +130,114 @@ fn getTurn(first_point: Point, middle_point: Point, last_point: Point) Turn {
 test "incremental convex hull with known result" {
     const allocator = testing.allocator;
 
-    var upperHull = try PointSet.init(&allocator, 2);
-    defer upperHull.deinit();
-    var lowerHull = try PointSet.init(&allocator, 2);
-    defer lowerHull.deinit();
+    var upper_hull = try PointSet.init(&allocator, 2);
+    defer upper_hull.deinit();
+    var lower_hull = try PointSet.init(&allocator, 2);
+    defer lower_hull.deinit();
 
     var point: Point = Point{ .time = 0, .value = 3 };
-    try addPointToConvexHull(&upperHull, &lowerHull, point);
+    try addPointToConvexHull(&upper_hull, &lower_hull, point);
     point.time = 1;
     point.value = 2;
-    try addPointToConvexHull(&upperHull, &lowerHull, point);
+    try addPointToConvexHull(&upper_hull, &lower_hull, point);
     point.time = 2;
     point.value = 3.5;
-    try addPointToConvexHull(&upperHull, &lowerHull, point);
+    try addPointToConvexHull(&upper_hull, &lower_hull, point);
     point.time = 3;
     point.value = 5;
-    try addPointToConvexHull(&upperHull, &lowerHull, point);
+    try addPointToConvexHull(&upper_hull, &lower_hull, point);
     point.time = 4;
     point.value = 3;
-    try addPointToConvexHull(&upperHull, &lowerHull, point);
+    try addPointToConvexHull(&upper_hull, &lower_hull, point);
     point.time = 5;
     point.value = 4;
-    try addPointToConvexHull(&upperHull, &lowerHull, point);
+    try addPointToConvexHull(&upper_hull, &lower_hull, point);
     point.time = 6;
     point.value = 4;
-    try addPointToConvexHull(&upperHull, &lowerHull, point);
+    try addPointToConvexHull(&upper_hull, &lower_hull, point);
     point.time = 7;
     point.value = 3;
-    try addPointToConvexHull(&upperHull, &lowerHull, point);
+    try addPointToConvexHull(&upper_hull, &lower_hull, point);
     point.time = 8;
     point.value = 4.5;
-    try addPointToConvexHull(&upperHull, &lowerHull, point);
+    try addPointToConvexHull(&upper_hull, &lower_hull, point);
     point.time = 9;
     point.value = 3.5;
-    try addPointToConvexHull(&upperHull, &lowerHull, point);
+    try addPointToConvexHull(&upper_hull, &lower_hull, point);
     point.time = 10;
     point.value = 2.5;
-    try addPointToConvexHull(&upperHull, &lowerHull, point);
+    try addPointToConvexHull(&upper_hull, &lower_hull, point);
     point.time = 11;
     point.value = 2.5;
-    try addPointToConvexHull(&upperHull, &lowerHull, point);
+    try addPointToConvexHull(&upper_hull, &lower_hull, point);
     point.time = 12;
     point.value = 3.5;
-    try addPointToConvexHull(&upperHull, &lowerHull, point);
+    try addPointToConvexHull(&upper_hull, &lower_hull, point);
     point.time = 13;
     point.value = 2.5;
-    try addPointToConvexHull(&upperHull, &lowerHull, point);
+    try addPointToConvexHull(&upper_hull, &lower_hull, point);
     point.time = 14;
     point.value = 2.5;
-    try addPointToConvexHull(&upperHull, &lowerHull, point);
+    try addPointToConvexHull(&upper_hull, &lower_hull, point);
     point.time = 15;
     point.value = 2.5;
-    try addPointToConvexHull(&upperHull, &lowerHull, point);
+    try addPointToConvexHull(&upper_hull, &lower_hull, point);
     point.time = 16;
     point.value = 3;
-    try addPointToConvexHull(&upperHull, &lowerHull, point);
+    try addPointToConvexHull(&upper_hull, &lower_hull, point);
     point.time = 17;
     point.value = 3;
-    try addPointToConvexHull(&upperHull, &lowerHull, point);
+    try addPointToConvexHull(&upper_hull, &lower_hull, point);
     point.time = 18;
     point.value = 3;
-    try addPointToConvexHull(&upperHull, &lowerHull, point);
+    try addPointToConvexHull(&upper_hull, &lower_hull, point);
     point.time = 19;
     point.value = 3;
-    try addPointToConvexHull(&upperHull, &lowerHull, point);
+    try addPointToConvexHull(&upper_hull, &lower_hull, point);
     point.time = 20;
     point.value = 2.8;
-    try addPointToConvexHull(&upperHull, &lowerHull, point);
+    try addPointToConvexHull(&upper_hull, &lower_hull, point);
 
-    try testing.expectEqual(5, upperHull.len);
-    try testing.expectEqual(4, lowerHull.len);
+    try testing.expectEqual(5, upper_hull.len);
+    try testing.expectEqual(4, lower_hull.len);
 
     // Expected Upper Hull.
-    try testing.expectEqual(0, upperHull.points[0].time);
-    try testing.expectEqual(3, upperHull.points[1].time);
-    try testing.expectEqual(8, upperHull.points[2].time);
-    try testing.expectEqual(19, upperHull.points[3].time);
-    try testing.expectEqual(20, upperHull.points[4].time);
+    try testing.expectEqual(0, upper_hull.points[0].time);
+    try testing.expectEqual(3, upper_hull.points[1].time);
+    try testing.expectEqual(8, upper_hull.points[2].time);
+    try testing.expectEqual(19, upper_hull.points[3].time);
+    try testing.expectEqual(20, upper_hull.points[4].time);
     // Expected Lower Hull.
-    try testing.expectEqual(0, lowerHull.points[0].time);
-    try testing.expectEqual(1, lowerHull.points[1].time);
-    try testing.expectEqual(15, lowerHull.points[2].time);
-    try testing.expectEqual(20, lowerHull.points[3].time);
+    try testing.expectEqual(0, lower_hull.points[0].time);
+    try testing.expectEqual(1, lower_hull.points[1].time);
+    try testing.expectEqual(15, lower_hull.points[2].time);
+    try testing.expectEqual(20, lower_hull.points[3].time);
 }
 
 test "incremental convex hull random elements" {
     const num_points: usize = 1000;
     const allocator = testing.allocator;
     var rnd = std.rand.DefaultPrng.init(0);
-    var upperHull = try PointSet.init(&allocator, num_points);
-    defer upperHull.deinit();
-    var lowerHull = try PointSet.init(&allocator, num_points);
-    defer lowerHull.deinit();
+    var upper_hull = try PointSet.init(&allocator, num_points);
+    defer upper_hull.deinit();
+    var lower_hull = try PointSet.init(&allocator, num_points);
+    defer lower_hull.deinit();
 
     var point: Point = Point{ .time = 0, .value = rnd.random().float(f64) };
     for (1..num_points) |i| {
-        try addPointToConvexHull(&upperHull, &lowerHull, point);
+        try addPointToConvexHull(&upper_hull, &lower_hull, point);
         point.time = i;
         point.value = rnd.random().float(f64);
     }
 
     // All points in the Upper Hull should turn to the right.
-    for (1..upperHull.len - 1) |i| {
-        const turn = getTurn(upperHull.points[i - 1], upperHull.points[i], upperHull.points[i + 1]);
+    for (1..upper_hull.len - 1) |i| {
+        const turn = getTurn(upper_hull.points[i - 1], upper_hull.points[i], upper_hull.points[i + 1]);
         try testing.expectEqual(turn, Turn.right);
     }
     // All points in the Lower Hull should turn to the left.
-    for (1..lowerHull.len - 1) |i| {
-        const turn = getTurn(lowerHull.points[i - 1], lowerHull.points[i], lowerHull.points[i + 1]);
+    for (1..lower_hull.len - 1) |i| {
+        const turn = getTurn(lower_hull.points[i - 1], lower_hull.points[i], lower_hull.points[i + 1]);
         try testing.expectEqual(turn, Turn.left);
     }
 }

--- a/src/functional/geometry/convex_hull.zig
+++ b/src/functional/geometry/convex_hull.zig
@@ -46,7 +46,7 @@ pub const PointSet = struct {
     // Initialize the container with a given `allocator` and max number of points `num_points`.
     // The max number of points it is not fixed. The max number of points will increase as more
     // elements are added.
-    pub fn init(allocator: *const std.mem.Allocator, num_points: usize) !PointSet {
+    pub fn init(allocator: *const mem.Allocator, num_points: usize) !PointSet {
         return PointSet{
             .points = try allocator.alloc(Point, num_points),
             .len = 0,

--- a/src/functional/geometry/convex_hull.zig
+++ b/src/functional/geometry/convex_hull.zig
@@ -214,24 +214,6 @@ test "incremental convex hull with elements degeneracy" {
     try testing.expectEqual(20, lowerHull.points[3].time);
 }
 
-test "incremental convex hull addPointToConvexHull re-allocate memory" {
-    const num_points: usize = 1000;
-    const allocator = testing.allocator;
-    var rnd = std.rand.DefaultPrng.init(0);
-
-    var upperHull = try PointSet.init(&allocator, 10);
-    defer upperHull.deinit();
-    var lowerHull = try PointSet.init(&allocator, 10);
-    defer lowerHull.deinit();
-    var point: Point = Point{ .time = 0, .value = rnd.random().float(f64) };
-    try addPointToConvexHull(&upperHull, &lowerHull, point);
-    for (1..num_points) |i| {
-        try addPointToConvexHull(&upperHull, &lowerHull, point);
-        point.time = i;
-        point.value = rnd.random().float(f64);
-    }
-}
-
 test "incremental convex hull random elements" {
     const num_points: usize = 1000;
     const allocator = testing.allocator;

--- a/src/functional/geometry/convex_hull.zig
+++ b/src/functional/geometry/convex_hull.zig
@@ -13,11 +13,10 @@
 // limitations under the License.
 
 //! This file contains the Graham algorithm to incrementally create or maintain a convex hull
-//! as well as the necessary structures, enums, and auxiliary functions from the book.
-//! "Mark De Berg, and Marc van Kreveld. Computational geometry: algorithms
-//! and applications. Third Edition. Springer Science & Business Media, 2000.
-//! https://doi.org//10.1007/978-3-540-77974-2".
-//! This algorithm is necessary for the compression algorithms described in:
+//! as well as the necessary structures, enums, and auxiliary functions. The algorithm is described
+//! in: "Mark De Berg, and Marc van Kreveld. Computational geometry: algorithms and applications.
+//! Springer Science & Business Media, 2000. https://doi.org//10.1007/978-3-540-77974-2.
+//! Convex Hulls are necessary in the implementation of the compression algorithms [1] and [2].
 //! [1] https://doi.org/10.14778/1687627.1687645 (Slide Filter).
 //! [2] https://doi.org/10.1109/TSP.2006.875394 (Optimal PLA).
 
@@ -25,7 +24,8 @@ const std = @import("std");
 const mem = std.mem;
 const testing = std.testing;
 
-const Error = @import("../../tersets.zig").Error;
+const tersets = @import("../../tersets.zig");
+const Error = tersets.Error;
 
 /// Enum for the angle's `Turn` of three consecutive points. The angle can represent a `right` or
 /// `left` turn. If there is no turn, then the points are `colinear`.

--- a/src/functional/geometry/convex_hull.zig
+++ b/src/functional/geometry/convex_hull.zig
@@ -127,7 +127,7 @@ fn getTurn(first_point: Point, middle_point: Point, last_point: Point) Turn {
     return if (value > 0) Turn.right else Turn.left;
 }
 
-test "incremental convex hull with elements degeneracy" {
+test "incremental convex hull with known result" {
     const allocator = testing.allocator;
 
     var upperHull = try PointSet.init(&allocator, 2);

--- a/src/functional/geometry/convex_hull.zig
+++ b/src/functional/geometry/convex_hull.zig
@@ -78,7 +78,8 @@ pub const PointSet = struct {
     }
 };
 
-/// Graham algorithm to incrementally update the `upper_hull` and `lower_hull` given a new `point`.
+/// Graham algorithm to add a new point to `upper_hull` and `lower_hull`. The algorithm ensures
+/// that the upper and lower hull form a Convex Hull.
 pub fn addPointToConvexHull(upper_hull: *PointSet, lower_hull: *PointSet, point: Point) !void {
     if (upper_hull.len < 2) {
         // The first two points can be add directly.

--- a/src/functional/geometry/convex_hull.zig
+++ b/src/functional/geometry/convex_hull.zig
@@ -78,40 +78,38 @@ pub const PointSet = struct {
     }
 };
 
-/// Graham algorithm to incrementally update the `upperHull` and `lowerHull` given a new `point`.
-pub fn addPointToConvexHull(upperHull: *PointSet, lowerHull: *PointSet, point: Point) !void {
-    if (upperHull.len < 2) {
+/// Graham algorithm to incrementally update the `upper_hull` and `lower_hull` given a new `point`.
+pub fn addPointToConvexHull(upper_hull: *PointSet, lower_hull: *PointSet, point: Point) !void {
+    if (upper_hull.len < 2) {
         // The first two points can be add directly.
-        try upperHull.add(point);
+        try upper_hull.add(point);
     } else {
         // Update upper hull.
-        var top: usize = upperHull.len - 1;
+        var top: usize = upper_hull.len - 1;
         while ((top > 0) and (getTurn(
-            upperHull.points[top - 1],
-            upperHull.points[top],
+            upper_hull.points[top - 1],
+            upper_hull.points[top],
             point,
         ) != Turn.right)) : (top -= 1) {
-            try upperHull.pop();
+            try upper_hull.pop();
         }
-        top += 1;
-        try upperHull.add(point);
+        try upper_hull.add(point);
     }
 
-    if (lowerHull.len < 2) {
+    if (lower_hull.len < 2) {
         // The first two points can be add directly.
-        try lowerHull.add(point);
+        try lower_hull.add(point);
     } else {
         // Update lower hull.
-        var top: usize = lowerHull.len - 1;
+        var top: usize = lower_hull.len - 1;
         while ((top > 0) and (getTurn(
-            lowerHull.points[top - 1],
-            lowerHull.points[top],
+            lower_hull.points[top - 1],
+            lower_hull.points[top],
             point,
         ) != Turn.left)) : (top -= 1) {
-            try lowerHull.pop();
+            try lower_hull.pop();
         }
-        top += 1;
-        try lowerHull.add(point);
+        try lower_hull.add(point);
     }
 }
 

--- a/src/functional/geometry/convex_hull.zig
+++ b/src/functional/geometry/convex_hull.zig
@@ -22,6 +22,7 @@
 //! [2] https://doi.org/10.1109/TSP.2006.875394 (Optimal PLA).
 
 const std = @import("std");
+const mem = std.mem;
 const testing = std.testing;
 
 const Error = @import("../../tersets.zig").Error;
@@ -40,7 +41,7 @@ pub const PointSet = struct {
     points: []Point,
     len: usize,
     max_len: usize,
-    allocator: *const std.mem.Allocator,
+    allocator: *const mem.Allocator,
 
     // Initialize the container with a given `allocator` and max number of points `num_points`.
     // The max number of points it is not fixed. The max number of points will increase as more
@@ -201,13 +202,13 @@ test "incremental convex hull with elements degeneracy" {
     try testing.expectEqual(5, upperHull.len);
     try testing.expectEqual(4, lowerHull.len);
 
-    // Expected Upper Hull
+    // Expected Upper Hull.
     try testing.expectEqual(0, upperHull.points[0].time);
     try testing.expectEqual(3, upperHull.points[1].time);
     try testing.expectEqual(8, upperHull.points[2].time);
     try testing.expectEqual(19, upperHull.points[3].time);
     try testing.expectEqual(20, upperHull.points[4].time);
-    // Expected Lower Hull
+    // Expected Lower Hull.
     try testing.expectEqual(0, lowerHull.points[0].time);
     try testing.expectEqual(1, lowerHull.points[1].time);
     try testing.expectEqual(15, lowerHull.points[2].time);
@@ -248,12 +249,12 @@ test "incremental convex hull random elements" {
         point.value = rnd.random().float(f64);
     }
 
-    // All points in the Upper Hull should turn to the right
+    // All points in the Upper Hull should turn to the right.
     for (1..upperHull.len - 1) |i| {
         const turn = getTurn(upperHull.points[i - 1], upperHull.points[i], upperHull.points[i + 1]);
         try testing.expectEqual(turn, Turn.right);
     }
-    // All points in the Lower Hull should turn to the left
+    // All points in the Lower Hull should turn to the left.
     for (1..lowerHull.len - 1) |i| {
         const turn = getTurn(lowerHull.points[i - 1], lowerHull.points[i], lowerHull.points[i + 1]);
         try testing.expectEqual(turn, Turn.left);

--- a/src/functional/geometry/convex_hull.zig
+++ b/src/functional/geometry/convex_hull.zig
@@ -58,14 +58,15 @@ pub const ConvexHull = struct {
     }
 };
 
-/// Add a new `point` to a `hull` as soon as it finds a different angle `turn`.
+/// Auxiliary function to add a new `point` to a given `hull` of the convex hull. The function uses
+/// the given `turn` to correctly add the new point.
 fn addPointToHull(hull: *ArrayList(Point), turn: Turn, point: Point) !void {
     if (hull.items.len < 2) {
         // The first two points can be add directly.
         try hull.append(point);
     } else {
-        // Core idea of Graham's scan.
         var top: usize = hull.items.len - 1;
+        // Remove the last point as long as the `turn` is not the provided.
         while ((top > 0) and (computeTurn(
             hull.items[top - 1],
             hull.items[top],

--- a/src/functional/geometry/convex_hull.zig
+++ b/src/functional/geometry/convex_hull.zig
@@ -24,9 +24,8 @@ const mem = std.mem;
 const ArrayList = std.ArrayList;
 const testing = std.testing;
 
-// const tersets = @import("../../tersets.zig");
-// const Point = tersets.Point;
-pub const Point = struct { time: usize, value: f64 };
+const tersets = @import("../../tersets.zig");
+const Point = tersets.Point;
 
 /// Enum for the angle's `Turn` of three consecutive points A, B, and C. Essentially, it describes
 /// whether the path from A to B to C makes a `left` turn, a `right` turn, or continues in a

--- a/src/functional/swing_slide_filter.zig
+++ b/src/functional/swing_slide_filter.zig
@@ -305,7 +305,7 @@ test "swing filter zero error bound and even size compress and decompress" {
     const allocator = testing.allocator;
     const linear_function = LinearFunction{ .slope = 1, .intercept = 0.0 };
 
-    var list_values = std.ArrayList(f64).init(allocator);
+    var list_values = ArrayList(f64).init(allocator);
     defer list_values.deinit();
     var compressed_values = ArrayList(u8).init(allocator);
     defer compressed_values.deinit();
@@ -338,7 +338,7 @@ test "swing filter zero error bound and odd size compress and decompress" {
 
     const linear_function = LinearFunction{ .slope = 1, .intercept = 0.0 };
 
-    var list_values = std.ArrayList(f64).init(allocator);
+    var list_values = ArrayList(f64).init(allocator);
     defer list_values.deinit();
     var compressed_values = ArrayList(u8).init(allocator);
     defer compressed_values.deinit();
@@ -389,7 +389,7 @@ test "swing filter four random lines and random error bound compress and decompr
         },
     };
 
-    var list_values = std.ArrayList(f64).init(allocator);
+    var list_values = ArrayList(f64).init(allocator);
     defer list_values.deinit();
     var compressed_values = ArrayList(u8).init(allocator);
     defer compressed_values.deinit();

--- a/src/tersets.zig
+++ b/src/tersets.zig
@@ -27,7 +27,6 @@ pub const Error = error{
     IncorrectInput,
     NegativeErrorBound,
     OutOfMemory,
-    EmptySet,
 };
 
 /// The compression methods in TerseTS.
@@ -36,6 +35,9 @@ pub const Method = enum {
     PoorMansCompressionMean,
     SwingFilter,
 };
+
+/// A point represented by `time` and `value`.
+pub const Point = struct { time: usize, value: f64 };
 
 /// Margin to adjust the error bound for numerical stability. Reducing the error bound by this
 /// margin ensures that all the elements of the decompressed time series are within the error bound

--- a/src/tersets.zig
+++ b/src/tersets.zig
@@ -27,6 +27,7 @@ pub const Error = error{
     IncorrectInput,
     NegativeErrorBound,
     OutOfMemory,
+    EmptySet,
 };
 
 /// The compression methods in TerseTS.


### PR DESCRIPTION
This PR contains the Graham algorithm [1] for incrementally maintaining a convex hull defined by a lower and upper hull. We define the lower and upper hulls as point sets and create a new structure to manipulate the points. The PR also changes `src/capi.zig` adding a new kind of error to the Error list of TerseTS.

[1] Mark De Berg, and Marc van Kreveld. Computational geometry: algorithms and applications. Third Edition. Springer Science & Business Media, 2000. https://doi.org//10.1007/978-3-540-77974-2.