### PR TITLE
Make compress_* functions match other functions

### DIFF
--- a/src/functional/poor_mans_compression.zig
+++ b/src/functional/poor_mans_compression.zig
@@ -28,7 +28,7 @@ const Error = tersets.Error;
 
 /// Compress `uncompressed_values` within `error_bound` using "Poor Man’s Compression - Midrange"
 /// and write the result to `compressed_values`. If an error occurs it is returned.
-pub fn compress_midrange(
+pub fn compressMidrange(
     uncompressed_values: []const f64,
     compressed_values: *ArrayList(u8),
     error_bound: f32,
@@ -56,7 +56,7 @@ pub fn compress_midrange(
 
 /// Compress `uncompressed_values` within `error_bound` using "Poor Man’s Compression - Mean"
 /// and write the result to `compressed_values`. If an error occurs it is returned.
-pub fn compress_mean(
+pub fn compressMean(
     uncompressed_values: []const f64,
     compressed_values: *ArrayList(u8),
     error_bound: f32,
@@ -134,7 +134,7 @@ test "midrange can compress and decompress" {
     var decompressed_values = ArrayList(f64).init(allocator);
     defer decompressed_values.deinit();
 
-    try compress_midrange(uncompressed_values[0..], &compressed_values, 0);
+    try compressMidrange(uncompressed_values[0..], &compressed_values, 0);
     try decompress(compressed_values.items, &decompressed_values);
 
     try testing.expect(mem.eql(f64, uncompressed_values[0..], decompressed_values.items));
@@ -148,7 +148,7 @@ test "mean can compress and decompress" {
     var decompressed_values = ArrayList(f64).init(allocator);
     defer decompressed_values.deinit();
 
-    try compress_mean(uncompressed_values[0..], &compressed_values, 0);
+    try compressMean(uncompressed_values[0..], &compressed_values, 0);
     try decompress(compressed_values.items, &decompressed_values);
 
     try testing.expect(mem.eql(f64, uncompressed_values[0..], decompressed_values.items));

--- a/src/functional/swing_slide_filter.zig
+++ b/src/functional/swing_slide_filter.zig
@@ -37,7 +37,7 @@ const LinearFunction = struct {
 
 /// Compress `uncompressed_values` within `error_bound` using "Swing Filter" and write the
 /// result to `compressed_values`. If an error occurs it is returned.
-pub fn compress_swing(
+pub fn compressSwing(
     uncompressed_values: []const f64,
     compressed_values: *ArrayList(u8),
     error_bound: f32,
@@ -311,7 +311,7 @@ test "swing filter zero error bound and even size compress and decompress" {
 
     const uncompressed_values = list_values.items;
 
-    try compress_swing(uncompressed_values[0..], &compressed_values, error_bound);
+    try compressSwing(uncompressed_values[0..], &compressed_values, error_bound);
     try decompress(compressed_values.items, &decompressed_values);
 
     try testing.expect(tersets.isWithinErrorBound(
@@ -344,7 +344,7 @@ test "swing filter zero error bound and odd size compress and decompress" {
 
     const uncompressed_values = list_values.items;
 
-    try compress_swing(uncompressed_values[0..], &compressed_values, error_bound);
+    try compressSwing(uncompressed_values[0..], &compressed_values, error_bound);
     try decompress(compressed_values.items, &decompressed_values);
 
     try testing.expect(tersets.isWithinErrorBound(
@@ -395,7 +395,7 @@ test "swing filter four random lines and random error bound compress and decompr
 
     const uncompressed_values = list_values.items;
 
-    try compress_swing(uncompressed_values[0..], &compressed_values, error_bound);
+    try compressSwing(uncompressed_values[0..], &compressed_values, error_bound);
     try decompress(compressed_values.items, &decompressed_values);
 
     try testing.expect(tersets.isWithinErrorBound(

--- a/src/tersets.zig
+++ b/src/tersets.zig
@@ -18,7 +18,7 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 const ArrayList = std.ArrayList;
 
-const pmc = @import("functional/poor_mans_compression.zig");
+const poor_mans_compression = @import("functional/poor_mans_compression.zig");
 const swing_slide_filter = @import("functional/swing_slide_filter.zig");
 
 /// The errors that can occur in TerseTS.
@@ -65,13 +65,25 @@ pub fn compress(
 
     switch (method) {
         .PoorMansCompressionMidrange => {
-            try pmc.compress_midrange(uncompressed_values, &compressed_values, error_bound);
+            try poor_mans_compression.compressMidrange(
+                uncompressed_values,
+                &compressed_values,
+                error_bound,
+            );
         },
         .PoorMansCompressionMean => {
-            try pmc.compress_mean(uncompressed_values, &compressed_values, error_bound);
+            try poor_mans_compression.compressMean(
+                uncompressed_values,
+                &compressed_values,
+                error_bound,
+            );
         },
         .SwingFilter => {
-            try swing_slide_filter.compress_swing(uncompressed_values, &compressed_values, error_bound);
+            try swing_slide_filter.compressSwing(
+                uncompressed_values,
+                &compressed_values,
+                error_bound,
+            );
         },
     }
     try compressed_values.append(@intFromEnum(method));
@@ -97,7 +109,7 @@ pub fn decompress(
 
     switch (method) {
         .PoorMansCompressionMidrange, .PoorMansCompressionMean => {
-            try pmc.decompress(compressed_values_slice, &decompressed_values);
+            try poor_mans_compression.decompress(compressed_values_slice, &decompressed_values);
         },
         .SwingFilter => {
             try swing_slide_filter.decompress(compressed_values_slice, &decompressed_values);


### PR DESCRIPTION
This PR closes #23 by changing the names of the `compress_` functions to [camelCase](https://en.wikipedia.org/wiki/Naming_convention_(programming)#Examples_of_multiple-word_identifier_formats).