### PR TITLE
Remove remaining TODOs from the source code

### DIFF
--- a/bindings/python/tersets/__init__.py
+++ b/bindings/python/tersets/__init__.py
@@ -68,7 +68,7 @@ class __Configuration(Structure):
     _fields_ = [("method", c_byte), ("error_bound", c_float)]
 
 
-# Mirror TerseTS Method Enum.    
+# Mirror TerseTS Method Enum.
 @unique
 class Method(Enum):
     PoorMansCompressionMidrange = 0
@@ -90,17 +90,15 @@ def compress(values: List[float], error_bound: float, method: Method) -> bytes:
         # Method does not exists, raise error, and show available options.
         available_methods = ", ".join([member.name for member in Method])
         raise TypeError(f"'{method}' is not a valid TerseTS Method. Available method names are: {available_methods}")
-    
+
     configuration = __Configuration(method.value, error_bound)
-    
+
     error = __library.compress(
         uncompressed_values, byref(compressed_values), configuration
     )
 
     if error == 1:
-        # TODO: Handle different errors from TerseTS. 
-        raise ValueError("Unknown error.") 
-    
+        raise ValueError("Unknown error.")
 
     return compressed_values.data[: compressed_values.len]
 

--- a/src/tersets.zig
+++ b/src/tersets.zig
@@ -58,8 +58,6 @@ pub fn compress(
     method: Method,
     error_bound: f32,
 ) Error!ArrayList(u8) {
-    //TODO: Specify that TerseTS's timestamps are the values indices.
-
     if (uncompressed_values.len == 0) return Error.EmptyInput;
     if (error_bound < 0) return Error.NegativeErrorBound;
 


### PR DESCRIPTION
This PR converts the two remaining TODOs in the source code into GitHub issues so issues are managed consistently. The two new issues are #34 which replaces `TODO: Specify that TerseTS's timestamps are the values indices.` from `src/tersets.zig` and #36 which replaces `TODO: Handle different errors from TerseTS.` from `bindings/python/tersets/__init__.py`.