### PR TITLE
Adapt Point structure to a continous time axis

### DIFF
--- a/src/tersets.zig
+++ b/src/tersets.zig
@@ -38,7 +38,7 @@ pub const Method = enum {
 };
 
 /// A point represented by `time` and `value`.
-pub const Point = struct { time: usize, value: f64 };
+pub const Point = struct { time: f64, value: f64 };
 
 /// This structure models a straight line segment from `start_point` to `end_point`.
 pub const Segment = struct { start_point: Point, end_point: Point };
@@ -128,13 +128,17 @@ pub fn isWithinErrorBound(
     error_bound: f32,
 ) bool {
     if (uncompressed_values.len != decompressed_values.len) {
+        std.debug.print("\nHere not the same size\n", .{});
         return false;
     }
 
     for (0..uncompressed_values.len) |index| {
         const uncompressed_value = uncompressed_values[index];
         const decompressed_value = decompressed_values[index];
-        if (@abs(uncompressed_value - decompressed_value) > error_bound) return false;
+        if (@abs(uncompressed_value - decompressed_value) > error_bound) {
+            std.debug.print("\n{} and {}\n", .{ uncompressed_value, decompressed_value });
+            return false;
+        }
     }
     return true;
 }


### PR DESCRIPTION
This PR is related to #13 as "Slide Filter" needs a continuous time axis and currently, we only support discrete time (x-axis). There are two ways to address this problem. 1) Change the Point structure and the implementation of "Swing Filter" to properly utilize the new continuous time axis. 2) Create a new Point structure called ContinousPoint and make "Slide Filter" utilize only this ContinousPoint. I decided the first one is better although it creates changes all around in the Swing Filter's compress and decompress functions. After testing, everything is working well and the new Point is working as expected.    