### PR TITLE
Add generic Point and Segment structure

### DIFF
--- a/src/functional/geometry/convex_hull.zig
+++ b/src/functional/geometry/convex_hull.zig
@@ -25,14 +25,15 @@ const ArrayList = std.ArrayList;
 const testing = std.testing;
 
 const tersets = @import("../../tersets.zig");
-const Point = tersets.Point;
+const Point = tersets.DiscretePoint;
 
 /// Enum for the angle's `Turn` of three consecutive points A, B, and C. Essentially, it describes
 /// whether the path from A to B to C makes a `left` turn, a `right` turn, or continues in a
 /// straight line also called collinear.
 const Turn = enum(i8) { right, left, collinear };
 
-/// Convex Hull formed by an upper and lower hull.
+/// Convex Hull formed by an upper and lower hull. The hulls are formed by the input data with
+/// discrete time axis thus, `Point` is always represented by a `DiscretePoint`.
 pub const ConvexHull = struct {
     lower_hull: ArrayList(Point),
     upper_hull: ArrayList(Point),

--- a/src/functional/geometry/convex_hull.zig
+++ b/src/functional/geometry/convex_hull.zig
@@ -25,7 +25,7 @@ const ArrayList = std.ArrayList;
 const testing = std.testing;
 
 const tersets = @import("../../tersets.zig");
-const Point = tersets.DiscretePoint;
+const DiscretePoint = tersets.DiscretePoint;
 
 /// Enum for the angle's `Turn` of three consecutive points A, B, and C. Essentially, it describes
 /// whether the path from A to B to C makes a `left` turn, a `right` turn, or continues in a
@@ -33,16 +33,16 @@ const Point = tersets.DiscretePoint;
 const Turn = enum(i8) { right, left, collinear };
 
 /// Convex Hull formed by an upper and lower hull. The hulls are formed by the input data with
-/// discrete time axis thus, `Point` is always represented by a `DiscretePoint`.
+/// discrete time axis thus, the ConvexHull is always represented by `DiscretePoint`.
 pub const ConvexHull = struct {
-    lower_hull: ArrayList(Point),
-    upper_hull: ArrayList(Point),
+    lower_hull: ArrayList(DiscretePoint),
+    upper_hull: ArrayList(DiscretePoint),
 
     // Initialize the container with a given `allocator`.
     pub fn init(allocator: mem.Allocator) !ConvexHull {
         return ConvexHull{
-            .lower_hull = ArrayList(Point).init(allocator),
-            .upper_hull = ArrayList(Point).init(allocator),
+            .lower_hull = ArrayList(DiscretePoint).init(allocator),
+            .upper_hull = ArrayList(DiscretePoint).init(allocator),
         };
     }
 
@@ -53,14 +53,14 @@ pub const ConvexHull = struct {
     }
 
     /// Add a new `point` to the convex hull.
-    pub fn addPoint(self: *ConvexHull, point: Point) !void {
+    pub fn addPoint(self: *ConvexHull, point: DiscretePoint) !void {
         try addPointToHull(&self.upper_hull, Turn.right, point);
         try addPointToHull(&self.lower_hull, Turn.left, point);
     }
 
     /// Auxiliary function to add a new `point` to a given `hull` of the convex hull. The function uses
     /// the given `turn` to correctly add the new point.
-    fn addPointToHull(hull: *ArrayList(Point), turn: Turn, point: Point) !void {
+    fn addPointToHull(hull: *ArrayList(DiscretePoint), turn: Turn, point: DiscretePoint) !void {
         if (hull.items.len < 2) {
             // The first two points can be add directly.
             try hull.append(point);
@@ -82,7 +82,11 @@ pub const ConvexHull = struct {
 /// Compute turn created by the path from `first_point` to `middle_point` to `last_point`. If this
 /// function is part of the structure and does not use the `self` parameter, the compiler returns
 /// an error. However, since it is used for testing purposes it cannot be private.
-fn computeTurn(first_point: Point, middle_point: Point, last_point: Point) Turn {
+fn computeTurn(
+    first_point: DiscretePoint,
+    middle_point: DiscretePoint,
+    last_point: DiscretePoint,
+) Turn {
     const distance_last_middle: f64 = @floatFromInt(last_point.time - middle_point.time);
     const distance_middle_first: f64 = @floatFromInt(middle_point.time - first_point.time);
 

--- a/src/functional/swing_slide_filter.zig
+++ b/src/functional/swing_slide_filter.zig
@@ -26,8 +26,8 @@ const ArrayList = std.ArrayList;
 
 const tersets = @import("../tersets.zig");
 const Error = tersets.Error;
-const Point = tersets.Point;
-const Segment = tersets.Segment;
+const DiscretePoint = tersets.DiscretePoint;
+const DiscreteSegment = tersets.DiscreteSegment;
 
 /// Linear function of the form y = slope*x+intercept. It uses f80 for numerical stability.
 const LinearFunction = struct {
@@ -55,7 +55,7 @@ pub fn compressSwing(
     var current_linear_function: LinearFunction = .{ .slope = 0, .intercept = 0 };
 
     // Initialize the current segment with first two points.
-    var current_segment: Segment = .{
+    var current_segment: DiscreteSegment = .{
         .start_point = .{ .time = 0, .value = uncompressed_values[0] },
         .end_point = .{ .time = 1, .value = uncompressed_values[1] },
     };
@@ -195,7 +195,7 @@ pub fn compressSwing(
 
 /// Decompress `compressed_values` produced by "Swing Filter" and "Slide Filter" and write the
 /// result to `decompressed_values`. If an error occurs it is returned.
-pub fn decompress(
+pub fn decompressSwing(
     compressed_values: []const u8,
     decompressed_values: *ArrayList(f64),
 ) Error!void {
@@ -210,7 +210,7 @@ pub fn decompress(
     var first_timestamp: usize = 0;
     var index: usize = 0;
     while (index < compressed_lines_and_index.len) : (index += 3) {
-        const current_segment: Segment = .{
+        const current_segment: DiscreteSegment = .{
             .start_point = .{ .time = first_timestamp, .value = compressed_lines_and_index[index] },
             .end_point = .{
                 .time = @as(usize, @bitCast(compressed_lines_and_index[index + 2])) - 1,
@@ -236,7 +236,7 @@ pub fn decompress(
 }
 
 /// Computes the numerator of the slope derivate as in Eq. (6).
-fn computeSlopeDerivate(segment: Segment) f80 {
+fn computeSlopeDerivate(segment: DiscreteSegment) f80 {
     return (segment.end_point.value - segment.start_point.value) *
         usizeToF80(segment.end_point.time - segment.start_point.time);
 }
@@ -245,7 +245,7 @@ fn computeSlopeDerivate(segment: Segment) f80 {
 /// points of the `segment`. The linear function is swinged down or up based on the `error_bound`.
 /// If `error_bound` is negative, `linear_function` is swing down. It is swing up otherwise.
 fn updateSwingLinearFunction(
-    segment: Segment,
+    segment: DiscreteSegment,
     linear_function: *LinearFunction,
     error_bound: f32,
 ) void {
@@ -278,9 +278,9 @@ fn appendValue(comptime T: type, value: T, compressed_values: *std.ArrayList(u8)
     }
 }
 
-/// Computes the intercept coefficient of a linear function that passes through `point`
-/// with the given `slope` coefficient.
-fn computeInterceptCoefficient(slope: f80, point: Point) f80 {
+/// Computes the intercept coefficient of a linear function that passes through the `DiscretePoint`
+/// `point` with the given `slope` coefficient.
+fn computeInterceptCoefficient(slope: f80, point: DiscretePoint) f80 {
     return point.value - slope * usizeToF80(point.time);
 }
 
@@ -312,7 +312,7 @@ test "swing filter zero error bound and even size compress and decompress" {
     const uncompressed_values = list_values.items;
 
     try compressSwing(uncompressed_values[0..], &compressed_values, error_bound);
-    try decompress(compressed_values.items, &decompressed_values);
+    try decompressSwing(compressed_values.items, &decompressed_values);
 
     try testing.expect(tersets.isWithinErrorBound(
         uncompressed_values,
@@ -345,7 +345,7 @@ test "swing filter zero error bound and odd size compress and decompress" {
     const uncompressed_values = list_values.items;
 
     try compressSwing(uncompressed_values[0..], &compressed_values, error_bound);
-    try decompress(compressed_values.items, &decompressed_values);
+    try decompressSwing(compressed_values.items, &decompressed_values);
 
     try testing.expect(tersets.isWithinErrorBound(
         uncompressed_values,
@@ -396,7 +396,7 @@ test "swing filter four random lines and random error bound compress and decompr
     const uncompressed_values = list_values.items;
 
     try compressSwing(uncompressed_values[0..], &compressed_values, error_bound);
-    try decompress(compressed_values.items, &decompressed_values);
+    try decompressSwing(compressed_values.items, &decompressed_values);
 
     try testing.expect(tersets.isWithinErrorBound(
         uncompressed_values,

--- a/src/functional/swing_slide_filter.zig
+++ b/src/functional/swing_slide_filter.zig
@@ -278,8 +278,8 @@ fn appendValue(comptime T: type, value: T, compressed_values: *std.ArrayList(u8)
     }
 }
 
-/// Computes the intercept coefficient of a linear function that passes through the `DiscretePoint`
-/// `point` with the given `slope` coefficient.
+/// Computes the intercept coefficient of a linear function that passes through the `point` with
+/// the given `slope` coefficient.
 fn computeInterceptCoefficient(slope: f80, point: DiscretePoint) f80 {
     return point.value - slope * usizeToF80(point.time);
 }

--- a/src/tersets.zig
+++ b/src/tersets.zig
@@ -37,11 +37,11 @@ pub const Method = enum {
     SwingFilter,
 };
 
-/// `Segment` with discrete `time` axis. `time_type` is type `usize` and `value_type` is `f64`.
-pub const DiscreteSegment = Segment(usize, f64);
+/// `Segment` with discrete `time` axis. `time_type` is type `usize`.
+pub const DiscreteSegment = Segment(usize);
 
-/// `Point` with discrete `time` axis. `time_type` is type `usize` and `value_type` is `f64`.
-pub const DiscretePoint = Point(usize, f64);
+/// `Point` with discrete `time` axis. `time_type` is type `usize`.
+pub const DiscretePoint = Point(usize);
 
 /// Margin to adjust the error bound for numerical stability. Reducing the error bound by this
 /// margin ensures that all the elements of the decompressed time series are within the error bound
@@ -151,16 +151,16 @@ pub fn getMaxMethodIndex() usize {
     return max_index;
 }
 
-/// `Point` is a point represented by `time` and `value` of datatype `time_type` and `value_type`.
-fn Point(comptime time_type: type, comptime value_type: type) type {
-    return struct { time: time_type, value: value_type };
+/// `Point` is a point represented by `time` and `value`. `time` is of datatype `time_type`.
+fn Point(comptime time_type: type) type {
+    return struct { time: time_type, value: f64 };
 }
 
-/// `Segment` models a straight line segment from `start_point` to `end_point`. The `time` and
-/// `value` datatypes of the points are determined by `time_type` and `value_type`.
-fn Segment(comptime time_type: type, comptime value_type: type) type {
+/// `Segment` models a straight line segment from `start_point` to `end_point`. `time` is of
+///  datatype `time_type`.
+fn Segment(comptime time_type: type) type {
     return struct {
-        start_point: Point(time_type, value_type),
-        end_point: Point(time_type, value_type),
+        start_point: Point(time_type),
+        end_point: Point(time_type),
     };
 }

--- a/src/tersets.zig
+++ b/src/tersets.zig
@@ -37,11 +37,11 @@ pub const Method = enum {
     SwingFilter,
 };
 
-/// A point represented by `time` and `value`.
-pub const Point = struct { time: usize, value: f64 };
+/// `Segment` with discrete `time` axis. `time_type` is type `usize` and `value_type` is `f64`.
+pub const DiscreteSegment = Segment(usize, f64);
 
-/// This structure models a straight line segment from `start_point` to `end_point`.
-pub const Segment = struct { start_point: Point, end_point: Point };
+/// `Point` with discrete `time` axis. `time_type` is type `usize` and `value_type` is `f64`.
+pub const DiscretePoint = Point(usize, f64);
 
 /// Margin to adjust the error bound for numerical stability. Reducing the error bound by this
 /// margin ensures that all the elements of the decompressed time series are within the error bound
@@ -112,7 +112,7 @@ pub fn decompress(
             try poor_mans_compression.decompress(compressed_values_slice, &decompressed_values);
         },
         .SwingFilter => {
-            try swing_slide_filter.decompress(compressed_values_slice, &decompressed_values);
+            try swing_slide_filter.decompressSwing(compressed_values_slice, &decompressed_values);
         },
     }
 
@@ -149,4 +149,18 @@ pub fn getMaxMethodIndex() usize {
     }
 
     return max_index;
+}
+
+/// `Point` is a point represented by `time` and `value` of datatype `time_type` and `value_type`.
+fn Point(comptime time_type: type, comptime value_type: type) type {
+    return struct { time: time_type, value: value_type };
+}
+
+/// `Segment` models a straight line segment from `start_point` to `end_point`. The `time` and
+/// `value` datatypes of the points are determined by `time_type` and `value_type`.
+fn Segment(comptime time_type: type, comptime value_type: type) type {
+    return struct {
+        start_point: Point(time_type, value_type),
+        end_point: Point(time_type, value_type),
+    };
 }


### PR DESCRIPTION
This PR implements a generic function to create Points and Segments in TerseTS. Currently, "Swing Filter" only requires discrete time-axis points and segments, however, "Slide Filter" requires continuous time-axis points and segments. Based on the comments made by @skejserjensen in https://github.com/cmcuza/TerseTS/pull/38#issue-2344112220, such a generic function allows us to create more effective structures depending on the needs of each compression method. Thus, https://github.com/cmcuza/TerseTS/pull/38#issue-2344112220 was closed and this new PR was created.