### PR TITLE
Add Sim-Piece

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
   <img src="docs/tersets.jpg" alt="TerseTS">
 </h1>
 
-TerseTS is a library that provides methods for lossless and lossy compressing time series. To match existing literature the methods are organized based on [Time Series Compression Survey](https://dl.acm.org/doi/10.1145/3560814). The library is implemented in Zig and provides a C-API with [bindings](#Installation) for other languages.
+TerseTS is a library that provides methods for lossless and lossy compressing time series. To match existing literature the methods are organized based on [Time Series Compression Survey](https://dl.acm.org/doi/10.1145/3560814). The library is implemented in Zig and provides a Zig-API and C-API with [bindings](#usage) for other languages.
 
-# Installation
+# Getting Started 
+## Compilation
 TerseTS can be compiled and cross-compiled from source:
 1. Install the latest version of [Zig](https://ziglang.org/)
 2. Build TerseTS for development in `Debug` mode using Zig, e.g.,:
@@ -16,15 +17,177 @@ TerseTS can be compiled and cross-compiled from source:
    - macOS: `zig build -Dtarget=aarch64-macos -Doptimize=ReleaseFast`
    - Microsoft Windows: `zig build -Dtarget=x86_64-windows -Doptimize=ReleaseFast`
 
-# Usage
-TODO
+## Usage
+TerseTS provides a Zig-API and a C-API that is designed to be simple to wrap. Currently, TerseTS includes APIs for the following programming languages which can be used without installation of any dependencies:
+<a id="zig-usage-example"></a>
+<details>
+<summary><strong>Zig Usage Example</strong></summary>
 
-# Bindings
-TerseTS provides a C-API that is designed to be simple to wrap. Currently, TerseTS includes bindings for the following programming languages which can be used without installation of any dependencies:
-- [Zig](src/tersets.zig)
-- [C](bindings/c/tersets.h)
-- [C++](bindings/c/tersets.h)
-- [Python](bindings/python/tersets) using [ctypes](https://docs.python.org/3/library/ctypes.html)
+```c
+const std = @import("std");
+const tersets = @import("path/to/tersets.zig");
+const gpa = std.heap.GeneralPurposeAllocator(.{}){};
+const allocator = gpa.allocator();
+
+pub fn main() void {
+   var uncompressed_values = [_]f64{1.0, 2.0, 3.0, 4.0, 5.0};
+   std.debug.print("Uncompressed data length: {any}\n", .{uncompressed_values.len});
+   
+   // Configuration for compression. 
+   // The supported compression methods are specified in tersets.zig.
+   const method = tersets.Method.SwingFilter;
+   const error_bound: f32 = 0.1;
+   
+   // Compress the data. 
+   var compressed_values = try tersets.compress(uncompressed_values, allocator, method, error_bound);
+   // The compressed values point to dynamically allocated data that should be deallocated.
+   defer compressed_values.deinit();
+
+   std.debug.print("Compression successful. Compressed data length: {any}\n", .{compressed_values.items.len});
+    
+   // Decompress the data. 
+   var decompressed_values = try tersets.decompress(compressed_values, allocator);
+   // The decompressed values point to dynamically allocated data that should be deallocated.
+   defer decompressed_values.deinit();
+
+   std.debug.print("Decompression successful. Decompressed data length {any}\n", .{decompressed_values.items.len});
+}
+```
+
+TerseTS provides `./src/tersets.zig` as the single access point and two main functions `compress()` and `decompress()`. 
+
+- **`compress()` Function:** 
+   - **Parameters:**
+      - `uncompressed_values`: The array of values to compress.
+      - `allocator`: Used to allocate memory for the returned `compressed_values` and other intermediate structures needed for compression.
+      - `method`: Compression method identifier as specified in `tersets.Method`, e.g., `tersets.Method.SwingFilter`. The supported compression methods are specified in `src/tersets.zig`. 
+      - `error_bound`: An error bound of type `f32`. 
+   - **Returns:** A dynamically allocated `compressed_values: ArrayList`, which must be deallocated with `deinit()`.
+- **`decompress()` Function:** 
+   - **Parameters:**
+      - `compressed_values`: The compressed data to decompress.
+      - `allocator`: Used to allocate memory for the returned `decompressed_values`.
+   - **Returns:** A dynamically allocated `decompressed_values: ArrayList`, which must be deallocated with `deinit()`.   
+</details>
+
+<a id="c-usage-example"></a>
+<details>
+<summary><strong>C Usage Example</strong></summary>
+
+```c 
+#include "tersets.h"
+#include <stdio.h>
+
+int main() {
+   double uncompressed_values[] = {1.0, 2.0, 3.0, 4.0, 5.0};
+   struct UncompressedValues uncompressed_values = {data, 5};
+   
+   printf("Uncompressed data length: %lu\n", uncompressed_values.len);
+   
+   // Configuration for compression. 
+   // The supported compression methods are specified in tersets.zig.
+   // Method 2 is SwingFilter and 0.1 error bound.
+   struct Configuration config = {2, 0.1}; 
+
+   // Prepare for compressed data. 
+   // The compressed values point to dynamically allocated data that should be deallocated.
+   struct CompressedValues compressed_values;
+    
+   // Compress the data.
+   int32_t result = compress(uncompressed_values, &compressed_values, config);
+   if (result != 0) {
+      printf("Compression failed with error code %d\n", result);
+      return -1;
+   }
+
+   printf("Compression successful. Decompressed data length: %lu\n", compressed_values.len);
+    
+   // Prepare for decompressed data. 
+   // The decompressed values point to dynamically allocated data that should be deallocated.
+   struct UncompressedValues decompressed_values;
+   
+   // Decompress the data.
+   int32_t result = decompress(compressed_values, &decompressed_values);
+   if (result != 0) {
+      printf("Decompression failed with error code %d\n", result);
+      return -1;
+   }
+
+   printf("Decompression successful. Decompressed data length: %lu\n", decompressed_values.len);
+    
+   // Free the compressed and decompressed values.
+   free(decompressed_values.data);
+   free(compressed_values.data);
+   return 0;
+}
+```
+
+TerseTS provides `./bindings/c/tersets.h` as API for C which should be included in the source code, i.e., `#include "tersets.h"`. The TerseTS library must also be [linked](#linking) to the project. 
+
+- **`compress()` Function:** 
+   - **Parameters:**
+      - `uncompressed_values`: The array of values to compress.
+      - `compressed_values`: A pointer to a structure where the compressed values will be stored. The data is dynamically allocated.
+      - `config`: The configuration structure specifying the compression method and error bound. The supported compression methods are specified in `src/tersets.zig`. 
+   - **Returns:** An integer indicating success `(0)` or an error code.
+- **`decompress()` Function:** 
+   - **Parameters:**
+      - `compressed_values`: The compressed data to decompress.
+      - `decompressed_values`: A pointer to a structure where the decompressed values will be stored. The data is dynamically allocated.
+   - **Returns:** An integer indicating success `(0)` or an error code.
+
+Remember to free dynamically allocated memory appropriately to avoid memory leaks.
+</details>
+
+<a id="python-usage-example"></a>
+<details>
+<summary><strong>Python Usage Example</strong></summary>
+
+```python
+import random
+import sys
+from tersets import compress, decompress, Method
+
+uncompressed_values = [1.0, 2.0, 3.0, 4.0, 5.0]
+
+# Configuration for compression. 
+# The supported compression methods are specified in tersets.zig.
+method = Method.SwingFilter
+error_bound = 0.1
+
+print("Uncompressed data length: ", len(uncompressed_values))
+
+# The supported compression methods are specified in tersets.zig.
+# The Python-API provides a `Method` enum to access the available methods.
+# Compress the data.
+compressed_values = compress(uncompressed, method, error_bound)
+
+print("Compression successful. Compressed data length: ", len(compressed_values))
+
+# Decompress the data.
+decompressed_values = decompress(compressed_values)
+
+print("Decompression successful. Decompressed data length: ", len(decompressed_values))
+```
+
+TerseTS provides `./bindings/python/tersets/__init__.py` as binding for Python which can be imported directly into a Python program with `import tersets`. The binding automatically loads the native library but assumes it is not moved.
+
+- **`compress()` Function:** 
+   - **Parameters:**
+      - `uncompressed_values`: The array of values to compress.
+      - `method`: The Python binding provides the `Method` enum to provide direct access to the available methods supported by `TerseTS`. The supported compression methods are specified in `src/tersets.zig`. 
+      - `error_bound`: The error bound. 
+   - **Returns:** A list of compressed values.
+- **`decompress()` Function:** 
+   - **Parameters:**
+      - `compressed_values`: The compressed data to decompress.
+   - **Returns:** A list of decompressed values.
+</details>
+
+## Linking:
+- **Microsoft Windows**: Link the `tersets.dll` to the project. It can be found in the output folder after compiling TerseTS, by default: `zig-out/lib/tersets.dll`.
+- **Linux**: Link the `tersets.so` to the project. It can be found in the output folder after compiling TerseTS, by default: `zig-out/lib/tersets.so`.
+- **macOS**: Link the `tersets.dylib` to the project. It can be found in the output folder after compiling TerseTS, by default: `zig-out/lib/tersets.dylib`.
 
 # License
 TerseTS is licensed under version 2.0 of the Apache License and a copy of the license is bundled with the program.

--- a/bindings/python/tersets/__init__.py
+++ b/bindings/python/tersets/__init__.py
@@ -77,7 +77,7 @@ class Method(Enum):
 
 
 # Public Functions.
-def compress(values: List[float], error_bound: float, method: Method) -> bytes:
+def compress(values: List[float], method: Method, error_bound: float) -> bytes:
     """Compresses values."""
 
     uncompressed_values = __UncompressedValues()

--- a/bindings/python/tests/__init__.py
+++ b/bindings/python/tests/__init__.py
@@ -27,6 +27,6 @@ class TerseTSPythonTest(unittest.TestCase):
             random.uniform(sys.float_info.min, sys.float_info.max)
             for _ in range(0, TEST_VALUE_COUNT)
         ]
-        compressed = compress(uncompressed, 0.0, Method.SwingFilter)
+        compressed = compress(uncompressed, Method.SwingFilter, 0.0)
         decompressed = decompress(compressed)
         self.assertEqual(uncompressed, decompressed)

--- a/src/capi.zig
+++ b/src/capi.zig
@@ -102,7 +102,7 @@ fn errorToInt(err: Error) i32 {
     switch (err) {
         Error.UnknownMethod => return 1,
         Error.EmptyInput => return 2,
-        Error.NegativeErrorBound => return 3,
+        Error.UnsupportedErrorBound => return 3,
         Error.IncorrectInput => return 4,
         Error.OutOfMemory => return 5,
     }

--- a/src/functional/sim_piece.zig
+++ b/src/functional/sim_piece.zig
@@ -1,0 +1,113 @@
+// Copyright 2024 TerseTS Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Implementation of the Sim-Piece algorithm from the paper
+//! "Xenophon Kitsios, Panagiotis Liakos, Katia Papakonstantinopoulou, and Yannis Kotidis.
+//! Sim-Piece: Highly Accurate Piecewise Linear Approximation through Similar Segment Merging.
+//! Proc. VLDB Endow. 16, 8 2023.
+//! https://doi.org/10.14778/3594512.3594521".
+
+const std = @import("std");
+const math = std.math;
+const mem = std.mem;
+const testing = std.testing;
+const ArrayList = std.ArrayList;
+
+const tersets = @import("../tersets.zig");
+const Error = tersets.Error;
+const DiscretePoint = tersets.DiscretePoint;
+
+const SimPieceContainer = struct {
+    timestamp: usize,
+    intercept: f64,
+    upper_bound_slope: f64,
+    lower_bound_slope: f64,
+};
+
+/// Compress `uncompressed_values` within `error_bound` using "Sim-Piece" and write the
+/// result to `compressed_values`. If an error occurs it is returned.
+pub fn compressSimPiece(
+    uncompressed_values: []const f64,
+    compressed_values: *ArrayList(u8),
+    allocator: mem.Allocator,
+    error_bound: f32,
+) Error!void {
+    // Adjust the error bound to avoid exceeding it during decompression.
+    const adjusted_error_bound = if (error_bound > 0)
+        error_bound - tersets.ErrorBoundMargin
+    else
+        error_bound;
+
+    var simpiece_container_list = ArrayList(SimPieceContainer).init(allocator);
+    defer simpiece_container_list.deinit();
+
+    var upper_bound_slope: f64 = math.f64_max;
+    var lower_bound_slope: f64 = math.f64_min;
+
+    // Initialize the `start_point` with the first uncompressed value.
+    var start_point: DiscretePoint = .{ .time = 0, .value = uncompressed_values[0] };
+
+    var quantized_start_value = quantize(uncompressed_values[0], adjusted_error_bound);
+
+    // First point already part of `current_segment`, next point is at index one.
+    var current_timestamp: usize = 1;
+    while (current_timestamp < uncompressed_values.len) : (current_timestamp += 1) {
+        const end_point: DiscretePoint = .{
+            .time = current_timestamp,
+            .value = uncompressed_values[current_timestamp],
+        };
+
+        const segment_size: usize = current_timestamp - start_point.time;
+        const upper_limit: f64 = upper_bound_slope * segment_size + quantized_start_value;
+        const lower_limit: f64 = lower_bound_slope * segment_size + quantized_start_value;
+
+        if (segment_size > 2) {
+            if ((upper_limit < (end_point.value - adjusted_error_bound)) or
+                ((lower_limit > (end_point.value + adjusted_error_bound))))
+            {
+                simpiece_container_list.append(.{
+                    .timestamp = start_point.time,
+                    .intercept = quantized_start_value,
+                    .upper_bound_slope = upper_bound_slope,
+                    .lower_bound_slope = lower_bound_slope,
+                });
+                start_point = end_point;
+                quantized_start_value = quantize(start_point.value, adjusted_error_bound);
+                continue;
+            }
+        }
+
+        const new_upper_bound_slope: f64 =
+            (end_point.value + adjusted_error_bound - quantized_start_value) / segment_size;
+        const new_lower_bound_slope: f64 =
+            (end_point.value - adjusted_error_bound - quantized_start_value) / segment_size;
+        if (segment_size == 2) {
+            upper_bound_slope = new_upper_bound_slope;
+            lower_bound_slope = new_lower_bound_slope;
+        } else {
+            if (end_point.value + adjusted_error_bound < upper_limit)
+                upper_bound_slope = @max(new_upper_bound_slope, lower_limit);
+            if (end_point.value - adjusted_error_bound > lower_limit)
+                lower_bound_slope = @min(new_lower_bound_slope, upper_limit);
+        }
+    }
+}
+
+// fn compressSimPiecePhaseOne()
+
+/// Quantizes the given `value` by the specified `error_bound`. This process ensures that
+/// the quantized value remains within the error bound of the original value.
+fn quantize(value: f64, error_bound: f32) f64 {
+    return @floor(value / error_bound) * error_bound;
+}

--- a/src/functional/sim_piece.zig
+++ b/src/functional/sim_piece.zig
@@ -487,7 +487,7 @@ fn appendSegmentMetadata(
     try get_result.value_ptr.*.append(metadata);
 }
 
-/// Returns a comparator function that compares SegmentMetadata by `lower_bound_slope`.
+/// Compares `metadata_one` and `metadata_two` by their lower bound slope.
 fn compareMetadataBySlope(
     _: void,
     metadata_one: SegmentMetadata,
@@ -496,7 +496,7 @@ fn compareMetadataBySlope(
     return metadata_one.lower_bound_slope < metadata_two.lower_bound_slope;
 }
 
-/// Returns a comparator function that compares SegmentMetadata by `start_time`.
+/// Compares `metadata_one` and `metadata_two` by their start time.
 fn compareMetadataByStartTime(
     _: void,
     metadata_one: SegmentMetadata,

--- a/src/functional/sim_piece.zig
+++ b/src/functional/sim_piece.zig
@@ -23,16 +23,32 @@ const math = std.math;
 const mem = std.mem;
 const testing = std.testing;
 const ArrayList = std.ArrayList;
+const HashMap = std.HashMap;
+const AutoHashMap = std.AutoHashMap;
 
 const tersets = @import("../tersets.zig");
 const Error = tersets.Error;
 const DiscretePoint = tersets.DiscretePoint;
 
-const SimPieceContainer = struct {
-    timestamp: usize,
-    intercept: f64,
+/// `SegmentMetadata` stores the information about a approximated segment during the execution
+/// of Sim-Piece. It stores the starting time of the segment in `start_time` and the slopes of
+/// the upper and lower bounds that constraint the linear approximation in that segment.
+const SegmentMetadata = struct {
+    start_time: usize,
     upper_bound_slope: f64,
     lower_bound_slope: f64,
+};
+
+const Hash64Context = struct {
+    const epsilon: f64 = 1e-10;
+
+    pub fn hash(_: Hash64Context, value: f64) u64 {
+        return @as(u64, @bitCast(value));
+    }
+
+    pub fn eql(_: Hash64Context, value_one: f64, value_two: f64) bool {
+        return @abs(value_one - value_two) < epsilon;
+    }
 };
 
 /// Compress `uncompressed_values` within `error_bound` using "Sim-Piece" and write the
@@ -49,11 +65,63 @@ pub fn compressSimPiece(
     else
         error_bound;
 
-    var simpiece_container_list = ArrayList(SimPieceContainer).init(allocator);
-    defer simpiece_container_list.deinit();
+    var segments_metadata_map = HashMap(
+        f64,
+        ArrayList(SegmentMetadata),
+        Hash64Context,
+        std.hash_map.default_max_load_percentage,
+    ).init(allocator);
+    defer segments_metadata_map.deinit();
 
-    var upper_bound_slope: f64 = math.f64_max;
-    var lower_bound_slope: f64 = math.f64_min;
+    // Sim-Piece Phase 1: Compute the Segment Metadata Map.
+    try computeSegmentsMetadataMap(
+        uncompressed_values,
+        &segments_metadata_map,
+        allocator,
+        adjusted_error_bound,
+    );
+
+    var merged_segments_metadata = ArrayList(SegmentMetadata).init(allocator);
+    merged_segments_metadata.deinit();
+
+    // Sim-Piece Phase 2: Merge the segments.
+    try computeMergedSegmentsMetadata(
+        segments_metadata_map,
+        &merged_segments_metadata,
+        allocator,
+    );
+
+    var reshaped_segments_metadata = AutoHashMap(usize, HashMap(
+        f64,
+        ArrayList(usize),
+        Hash64Context,
+        std.hash_map.default_max_load_percentage,
+    )).init(allocator);
+    reshaped_segments_metadata.deinit();
+
+    // Sim-Piece Phase 3: Reshape segment metadata to output.
+    // reshapeSegmentsMetadata(
+    //     merged_segments_metadata,
+    //     &reshaped_segments_metadata,
+    // );
+    try compressed_values.append(0);
+}
+
+/// Sim-Piece Phase 1: Create the HashMap between the intercepts and each segment information
+/// stored on the `SegmentMetadata`.
+fn computeSegmentsMetadataMap(
+    uncompressed_values: []const f64,
+    segments_metadata_map: *HashMap(
+        f64,
+        ArrayList(SegmentMetadata),
+        Hash64Context,
+        std.hash_map.default_max_load_percentage,
+    ),
+    allocator: mem.Allocator,
+    adjusted_error_bound: f32,
+) !void {
+    var upper_bound_slope: f64 = math.floatMax(f64);
+    var lower_bound_slope: f64 = math.floatMin(f64);
 
     // Initialize the `start_point` with the first uncompressed value.
     var start_point: DiscretePoint = .{ .time = 0, .value = uncompressed_values[0] };
@@ -69,45 +137,162 @@ pub fn compressSimPiece(
         };
 
         const segment_size: usize = current_timestamp - start_point.time;
-        const upper_limit: f64 = upper_bound_slope * segment_size + quantized_start_value;
-        const lower_limit: f64 = lower_bound_slope * segment_size + quantized_start_value;
+        const upper_limit: f64 = upper_bound_slope * @as(
+            f64,
+            @floatFromInt(segment_size),
+        ) + quantized_start_value;
 
-        if (segment_size > 2) {
-            if ((upper_limit < (end_point.value - adjusted_error_bound)) or
-                ((lower_limit > (end_point.value + adjusted_error_bound))))
-            {
-                simpiece_container_list.append(.{
-                    .timestamp = start_point.time,
-                    .intercept = quantized_start_value,
-                    .upper_bound_slope = upper_bound_slope,
-                    .lower_bound_slope = lower_bound_slope,
-                });
-                start_point = end_point;
-                quantized_start_value = quantize(start_point.value, adjusted_error_bound);
-                continue;
-            }
-        }
+        const lower_limit: f64 = lower_bound_slope * @as(
+            f64,
+            @floatFromInt(segment_size),
+        ) + quantized_start_value;
 
-        const new_upper_bound_slope: f64 =
-            (end_point.value + adjusted_error_bound - quantized_start_value) / segment_size;
-        const new_lower_bound_slope: f64 =
-            (end_point.value - adjusted_error_bound - quantized_start_value) / segment_size;
-        if (segment_size == 2) {
-            upper_bound_slope = new_upper_bound_slope;
-            lower_bound_slope = new_lower_bound_slope;
+        if ((upper_limit < (end_point.value - adjusted_error_bound)) or
+            ((lower_limit > (end_point.value + adjusted_error_bound))))
+        {
+            // The new point is outside the upper and lower limit. Record a new segment metadata in
+            // `segments_metadata_map` associated to `quantized_start_value`.
+            try addSegmentMetadata(segments_metadata_map, .{
+                .start_time = start_point.time,
+                .upper_bound_slope = upper_bound_slope,
+                .lower_bound_slope = lower_bound_slope,
+            }, quantized_start_value, allocator);
+
+            start_point = end_point;
+            quantized_start_value = quantize(start_point.value, adjusted_error_bound);
+            upper_bound_slope = math.floatMax(f64);
+            lower_bound_slope = math.floatMin(f64);
         } else {
+            // The new point is within the upper and lower bounds. Update the bounds' slopes.
+            const new_upper_bound_slope: f64 =
+                (end_point.value + adjusted_error_bound - quantized_start_value) /
+                @as(f64, @floatFromInt(segment_size));
+            const new_lower_bound_slope: f64 =
+                (end_point.value - adjusted_error_bound - quantized_start_value) /
+                @as(f64, @floatFromInt(segment_size));
+
             if (end_point.value + adjusted_error_bound < upper_limit)
                 upper_bound_slope = @max(new_upper_bound_slope, lower_limit);
             if (end_point.value - adjusted_error_bound > lower_limit)
                 lower_bound_slope = @min(new_lower_bound_slope, upper_limit);
         }
     }
+
+    const segment_size: usize = current_timestamp - start_point.time;
+    if (segment_size != 0) {
+        try addSegmentMetadata(segments_metadata_map, .{
+            .start_time = start_point.time,
+            .upper_bound_slope = upper_bound_slope,
+            .lower_bound_slope = lower_bound_slope,
+        }, quantized_start_value, allocator);
+    }
 }
 
-// fn compressSimPiecePhaseOne()
+/// Sim-Piece Phase 2.
+fn computeMergedSegmentsMetadata(
+    segments_metadata_map: HashMap(
+        f64,
+        ArrayList(SegmentMetadata),
+        Hash64Context,
+        std.hash_map.default_max_load_percentage,
+    ),
+    merged_segments_metadata: *ArrayList(SegmentMetadata),
+    allocator: mem.Allocator,
+) !void {
+    var timestamps_array = ArrayList(usize).init(allocator);
+    defer timestamps_array.deinit();
+
+    var iterator = segments_metadata_map.iterator();
+    while (iterator.next()) |entry| {
+        const metadata_array = entry.value_ptr;
+        mem.sort(
+            SegmentMetadata,
+            metadata_array.items,
+            {},
+            comptime compareMetadata(SegmentMetadata),
+        );
+        var merge_metadata: SegmentMetadata = .{
+            .start_time = 0.0,
+            .lower_bound_slope = metadata_array.items[0].lower_bound_slope,
+            .upper_bound_slope = metadata_array.items[0].upper_bound_slope,
+        };
+        for (1..metadata_array.items.len) |index| {
+            const current_metadata = metadata_array.items[index];
+            try timestamps_array.append(current_metadata.start_time);
+            if ((current_metadata.lower_bound_slope <= merge_metadata.upper_bound_slope) and (current_metadata.upper_bound_slope >= merge_metadata.lower_bound_slope)) {
+                // The merged segment metadata belongs to the current segment metadata.
+                try timestamps_array.append(current_metadata.start_time);
+                merge_metadata.lower_bound_slope = @max(
+                    merge_metadata.lower_bound_slope,
+                    current_metadata.lower_bound_slope,
+                );
+                merge_metadata.upper_bound_slope = @min(
+                    merge_metadata.upper_bound_slope,
+                    current_metadata.upper_bound_slope,
+                );
+            } else {
+                // A new merged segment metadata needs to be created.
+                for (timestamps_array.items) |timestamp| {
+                    try merged_segments_metadata.append(.{
+                        .start_time = timestamp,
+                        .lower_bound_slope = merge_metadata.lower_bound_slope,
+                        .upper_bound_slope = merge_metadata.upper_bound_slope,
+                    });
+                }
+            }
+        }
+    }
+}
+
+/// Sim-Piece Phase 3. Reshape the input segment metadata array.
+// fn reshapeSegmentsMetadata(merged_segments_metadata: ArrayList(SegmentMetadata), reshaped_segments_metadata: *ArrayHashMap(f64, ArrayHashMap(f64, ArrayList(usize)))) !void {}
 
 /// Quantizes the given `value` by the specified `error_bound`. This process ensures that
 /// the quantized value remains within the error bound of the original value.
 fn quantize(value: f64, error_bound: f32) f64 {
     return @floor(value / error_bound) * error_bound;
+}
+
+fn addSegmentMetadata(
+    metadata_map: *HashMap(
+        f64,
+        ArrayList(SegmentMetadata),
+        Hash64Context,
+        std.hash_map.default_max_load_percentage,
+    ),
+    metadata: SegmentMetadata,
+    quantize_value: f64,
+    allocator: mem.Allocator,
+) !void {
+    const result = try metadata_map.getOrPut(quantize_value);
+    if (!result.found_existing) {
+        result.value_ptr.* = ArrayList(SegmentMetadata).init(allocator);
+    }
+    var metadata_array = result.value_ptr.*;
+    try metadata_array.append(metadata);
+}
+
+fn compareMetadata(comptime T: type) fn (void, T, T) bool {
+    return struct {
+        pub fn inner(_: void, metadata_one: T, metadata_two: T) bool {
+            return metadata_one.lower_bound_slope < metadata_two.lower_bound_slope;
+        }
+    }.inner;
+}
+
+/// Decompress `compressed_values` produced by "Swing Filter" and "Slide Filter" and write the
+/// result to `decompressed_values`. If an error occurs it is returned.
+pub fn decompress(
+    compressed_values: []const u8,
+    decompressed_values: *ArrayList(f64),
+) Error!void {
+    // The compressed representation is composed of three values: (start_value, end_value, end_time)
+    // all of type 64-bit float.
+    if (compressed_values.len % 24 != 0) return Error.IncorrectInput;
+
+    const compressed_lines_and_index = mem.bytesAsSlice(f64, compressed_values);
+
+    for (compressed_lines_and_index, 0..) |item, index| {
+        decompressed_values.items[index] = item;
+    }
 }

--- a/src/functional/sim_piece.zig
+++ b/src/functional/sim_piece.zig
@@ -18,11 +18,11 @@
 //! Proc. VLDB Endow. 16, 8 2023.
 //! https://doi.org/10.14778/3594512.3594521".
 //! The implementation is partially based on the authors implementation at
-//! https://github.com/xkitsios/Sim-Piece (accessed on 20-06-24). Few changes where made to support
-//! an error bound equals to zero and to improve numerical stability. This is because Sim-Piece
+//! https://github.com/xkitsios/Sim-Piece (accessed on 20-06-24). Few changes were made to support
+//! an error bound equal to zero and to improve numerical stability. This is because Sim-Piece
 //! does not support lossless compression. Setting `error_bound` to zero will cause an error due to
 //! undefined quantization (`b=floor(value/error_bound)*error_bound`). This has a ripple effect
-//! across the algorithm that demands the implementation of especial instructions to handle a zero
+//! across the algorithm that demands the implementation of special instructions to handle a zero
 //! error bound. Nevertheless, the numerical instabilities inherent to floating point operations
 //! mean that decompressed values will not exactly match the original uncompressed values. To alert
 //! the user, a warning is shown if the `error_bound` equals zero.

--- a/src/tersets.zig
+++ b/src/tersets.zig
@@ -141,7 +141,7 @@ pub fn decompress(
             try swing_slide_filter.decompress(compressed_values_slice, &decompressed_values);
         },
         .SimPiece => {
-            try sim_piece.decompress(compressed_values_slice, &decompressed_values);
+            try sim_piece.decompress(compressed_values_slice, &decompressed_values, allocator);
         },
     }
 

--- a/src/tersets.zig
+++ b/src/tersets.zig
@@ -20,6 +20,7 @@ const ArrayList = std.ArrayList;
 
 const poor_mans_compression = @import("functional/poor_mans_compression.zig");
 const swing_slide_filter = @import("functional/swing_slide_filter.zig");
+const sim_piece = @import("functional/sim_piece.zig");
 
 /// The errors that can occur in TerseTS.
 pub const Error = error{
@@ -36,6 +37,7 @@ pub const Method = enum {
     PoorMansCompressionMean,
     SwingFilter,
     SlideFilter,
+    SimPiece,
 };
 
 /// `Point` with discrete `time` axis.
@@ -101,6 +103,14 @@ pub fn compress(
                 error_bound,
             );
         },
+        .SimPiece => {
+            try sim_piece.compressSimPiece(
+                uncompressed_values,
+                &compressed_values,
+                allocator,
+                error_bound,
+            );
+        },
     }
     try compressed_values.append(@intFromEnum(method));
     return compressed_values;
@@ -129,6 +139,9 @@ pub fn decompress(
         },
         .SwingFilter, .SlideFilter => {
             try swing_slide_filter.decompress(compressed_values_slice, &decompressed_values);
+        },
+        .SimPiece => {
+            try sim_piece.decompress(compressed_values_slice, &decompressed_values);
         },
     }
 

--- a/src/tersets.zig
+++ b/src/tersets.zig
@@ -27,7 +27,7 @@ pub const Error = error{
     UnknownMethod,
     EmptyInput,
     IncorrectInput,
-    NegativeErrorBound,
+    UnsupportedErrorBound,
     OutOfMemory,
 };
 
@@ -69,7 +69,7 @@ pub fn compress(
     error_bound: f32,
 ) Error!ArrayList(u8) {
     if (uncompressed_values.len == 0) return Error.EmptyInput;
-    if (error_bound < 0) return Error.NegativeErrorBound;
+    if (error_bound < 0) return Error.UnsupportedErrorBound;
 
     var compressed_values = ArrayList(u8).init(allocator);
 


### PR DESCRIPTION
This PR adds the Sim-Piece compression algorithm from the paper [1] and Closes #19. The implementation is based on the authors' implementation at https://github.com/xkitsios/Sim-Piece (accessed 19-06-24). Few changes were made to support
an error bound equal to zero and to improve numerical stability. This is because Sim-Piece does not support lossless compression. Setting `error_bound` to zero will cause an error due to undefined quantization (`b=floor(value/error_bound)*error_bound`). This has a ripple effect across the algorithm that demands the implementation of special instructions to handle a zero error bound. Nevertheless, the numerical instabilities inherent to floating point operations mean that decompressed values will not exactly match the original uncompressed values. To alert the user, a warning is shown if the `error_bound` equals zero. By testing the method using an error bound equal to zero I found that decompressed values are at least approximately 1e-6 the uncompressed values. 

[1] https://doi.org/10.14778/3594512.3594521