### PR TITLE
Add usage example in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 TerseTS is a library that provides methods for lossless and lossy compressing time series. To match existing literature the methods are organized based on [Time Series Compression Survey](https://dl.acm.org/doi/10.1145/3560814). The library is implemented in Zig and provides a C-API with [bindings](#Installation) for other languages.
 
-# Installation
+# Usage
 TerseTS can be compiled and cross-compiled from source:
 1. Install the latest version of [Zig](https://ziglang.org/)
 2. Build TerseTS for development in `Debug` mode using Zig, e.g.,:
@@ -15,28 +15,46 @@ TerseTS can be compiled and cross-compiled from source:
    - Linux: `zig build -Dtarget=x86_64-linux -Doptimize=ReleaseFast`
    - macOS: `zig build -Dtarget=aarch64-macos -Doptimize=ReleaseFast`
    - Microsoft Windows: `zig build -Dtarget=x86_64-windows -Doptimize=ReleaseFast`
+4. Using TerseTS in Different Languages:
+   - TerseTS provides a C-API that is designed to be simple to wrap. Currently, TerseTS includes bindings for the following programming languages which can be used without installation of any dependencies.
+      - [Zig](src/tersets.zig). Check an example in [Zig Usage Example](#zig-usage-example).
+      - [C](bindings/c/tersets.h). Check an example in [C/C++ Usage Example](#c-usage-example).
+      - [C++](bindings/c/tersets.h). Check an example in [C/C++ Usage Example](#c-usage-example).
+      - [Python](bindings/python/tersets) using [ctypes](https://docs.python.org/3/library/ctypes.html). Check an example in [Python Usage Example](#python-usage-example).
+<details>
+<summary><strong>Zig</strong></summary>
 
-# Usage
+### Zig Usage Example
 
-To use TerseTS in a C project, follow these steps:
 
-1. **Installation**:
-   - Ensure TerseTS is installed and compiled as per the installation instructions.
+```rust
+const std = @import("std");
+const tersets = @import("path/to/tersets.zig");
 
-2. **Linking**:
-   - For Windows: Link the `tersets.dll` to your project.
-   - For Linux: Link the `libtersets.so` to your project.
-   - Include the header file `tersets/bindings/c/tersets.h` in your project.
+pub fn main() void {
+    var data = [_]f64{1.0, 2.0, 3.0, 4.0, 5.0};
+    const config = tersets.Configuration{
+        .method = .SwingFilter,
+        .error_bound = 0.0,
+    };
+    
+    var compressed = try tersets.compress(data[0..], config);
+    defer std.heap.page_allocator.free(compressed);
 
-3. **Include the Header**:
-   - Add `#include "tersets.h"` in your source files where you intend to use TerseTS functions. 
+    var decompressed = try tersets.decompress(compressed, config);
+    defer std.heap.page_allocator.free(decompressed);
 
-4. **Compression and Decompression Interface**:
-   - Use the provided interface to compress and decompress time series data.
+    std.debug.print("Decompression successful: {any}\n", .{decompressed});
+}
+```
+</details>
 
-### Example
+<details>
+<summary><strong>C</strong></summary>
 
-```c
+### C Usage Example
+
+```c 
 #include "tersets.h"
 #include <stdio.h>
 
@@ -79,27 +97,17 @@ int main() {
 }
 ```
 ### Notes
-1. Ensure that the method field in `Configuration` is set to a valid compression/decompression method supported by `TerseTS`.
-2. Free dynamically allocated memory appropriately to avoid memory leaks.
+1. Include the Header and Link the Library.
+2. Add #include "tersets.h" in your source files and link the TerseTS library to your project.
+3. Ensure that the method field in `Configuration` is set to a valid compression/decompression method supported by `TerseTS`.
+4. Free dynamically allocated memory appropriately to avoid memory leaks.
+</details>
 
-## Example Usage in Python
+<details>
+<summary><strong>Python</strong></summary>
 
-To use TerseTS in a Python project, follow these steps:
+### Python Usage Example
 
-1. **Installation**:
-   - Ensure TerseTS is installed and compiled as per the installation instructions.
-   - Ensure the Python bindings in `tersets/bindings/python/tersets` are available in your project.
-
-2. **Linking the Library**:
-   - Modify the `__init__.py` file in the TerseTS Python bindings to link the correct shared library for your operating system. Specifically, change the `library_path` variable to reflect the path to TerseTS's library.
-
-3. **Import the Library**:
-   - Import the necessary functions and classes from the TerseTS Python module.
-
-4. **Compression and Decompression Interface**:
-    - Use the following interface to compress and decompress time series data.
-
-### Example
 ```python
 import random
 import sys
@@ -123,14 +131,14 @@ decompressed = decompress(compressed)
 assert uncompressed == decompressed
 print("Compression and decompression were successful.")
 ```
+### Notes
+   1. Modify the `__init__.py` file in the TerseTS Python bindings to link the correct shared library for your operating system. Specifically, change the `library_path` variable to reflect the path to TerseTS's library.
+   2. Import the necessary functions and classes from the TerseTS Python module.
+
+</details>
 
 
-# Bindings
-TerseTS provides a C-API that is designed to be simple to wrap. Currently, TerseTS includes bindings for the following programming languages which can be used without installation of any dependencies:
-- [Zig](src/tersets.zig)
-- [C](bindings/c/tersets.h)
-- [C++](bindings/c/tersets.h)
-- [Python](bindings/python/tersets) using [ctypes](https://docs.python.org/3/library/ctypes.html)
+
 
 # License
 TerseTS is licensed under version 2.0 of the Apache License and a copy of the license is bundled with the program.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ const tersets = @import("path/to/tersets.zig");
 pub fn main() void {
    var uncompressed_values = [_]f64{1.0, 2.0, 3.0, 4.0, 5.0};
    std.debug.print("Uncompressed data length: {any}\n", .{uncompressed_values.len});
-    
+   
+   // The supported compression methods are specified in tersets.zig.
    const config = tersets.Configuration{
         .method = .SwingFilter,
         .error_bound = 0.1,
@@ -50,7 +51,7 @@ pub fn main() void {
 
 TerseTS provides `./src/tersets.zig` as the single access point and two main functions `compress` and `decompress`. 
 
-For compression, you can select the compression method through the `Configuration` structure with two parameters: the compression method, e.g., `.method=.SwingFilter`, and the error bound, e.g., `.error_bound = 0.1`. 
+For compression, you can select the compression method through the `Configuration` structure with two parameters: the compression method, e.g., `.method=.SwingFilter`, and the error bound, e.g., `.error_bound = 0.1`. The supported compression methods are specified in `src/tersets.zig`. 
 
 For decompression, the `Configuration` is not needed as the method is encoded in the compressed values.
 </details>
@@ -69,11 +70,13 @@ int main() {
    
    printf("Uncompressed data length: %lu\n", uncompressed_values.len);
    
-   // Configuration for compression.
+   // Configuration for compression. 
+   // The supported compression methods are specified in tersets.zig.
    // Method 2 is SwingFilter and 0.1 error bound.
    struct Configuration config = {2, 0.0}; 
 
-   // Prepare for compressed data.
+   // Prepare for compressed data. 
+   // The compressed values point to dynamically allocated data that should be deallocated.
    struct CompressedValues compressed_values;
     
    // Compress the data.
@@ -85,7 +88,8 @@ int main() {
 
    printf("Compression successful. Decompressed data length: %lu\n", compressed_values.len);
     
-   // Prepare for decompressed data.
+   // Prepare for decompressed data. 
+   // The decompressed values point to dynamically allocated data that should be deallocated.
    struct UncompressedValues decompressed_values;
    
    // Decompress the data.

--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ int main() {
 
 TerseTS provides `./bindings/c/tersets.h` as binding for C/C++, thus, the `#include "tersets.h"` in the source code. You need to link the TerseTS library to your project [linking](#linking).
 
--  Ensure that the method field in `Configuration` is set to a valid compression/decompression method supported by `TerseTS`.
+Ensure that the method field in `Configuration` is set to a valid compression/decompression method supported by `TerseTS`.
 
--  Free dynamically allocated memory appropriately to avoid memory leaks.
+Free dynamically allocated memory appropriately to avoid memory leaks.
 </details>
 
 <a id="python-usage-example"></a>

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ To use TerseTS from Python first ensure the `__init__.py` file in `binding/pytho
 
 </details>
 
-### Linking:
+## Linking:
 
 * **For Windows:** Link the `tersets.dll` to your project. `tersets.dll` can be found in the output folder after compiling TersetTS, by default: `zig-out/lib/tersets.dll`.  
 

--- a/README.md
+++ b/README.md
@@ -35,18 +35,18 @@ pub fn main() void {
    
    // Configuration for compression. 
    // The supported compression methods are specified in tersets.zig.
-   const method = tersets.Method.SwingFilter,
+   const method = tersets.Method.SwingFilter;
    const error_bound: f32 = 0.1;
    
    // Compress the data. 
-   var compressed_values = try tersets.compress(data[0..], allocator, method, error_bound);
+   var compressed_values = try tersets.compress(uncompressed_values, allocator, method, error_bound);
    // The compressed values point to dynamically allocated data that should be deallocated.
    defer compressed_values.deinit();
 
    std.debug.print("Compression successful. Compressed data length: {any}\n", .{compressed_values.items.len});
     
    // Decompress the data. 
-   var decompressed_values = try tersets.decompress(compressed, allocator);
+   var decompressed_values = try tersets.decompress(compressed_values, allocator);
    // The decompressed values point to dynamically allocated data that should be deallocated.
    defer decompressed_values.deinit();
 
@@ -56,7 +56,9 @@ pub fn main() void {
 
 TerseTS provides `./src/tersets.zig` as the single access point and two main functions `compress()` and `decompress()`. 
 
-The compression method can be selected through the `Configuration` structure with two parameters: the compression method, e.g., `.method=.SwingFilter`, and the error bound, e.g., `.error_bound=0.1`. The supported compression methods are specified in `src/tersets.zig`. 
+The `compress()` function receives the `uncompressed_values`, a `allocator` to allocate memory for the returned `compressed_values` and other intermediate structures needed for compression, a compression method identification, e.g, `tersets.Method.SwingFilter` and error bound of type `f32`. The supported compression methods are specified in `src/tersets.zig`. 
+
+The `decompress()` function receives the `compressed_values` and a `allocator` to allocate memory for the returned `decompressed_values`.
 </details>
 
 <a id="c-usage-example"></a>
@@ -113,7 +115,7 @@ int main() {
 
 TerseTS provides `./bindings/c/tersets.h` as API for C which should be included in the source code, i.e., `#include "tersets.h"`. The TerseTS library must also be [linked](#linking) to the project. 
 
-Ensure that the method field in `Configuration` is set to a valid compression/decompression method supported by `TerseTS`.
+The compression method can be selected through the `Configuration` structure with two parameters: the compression method, and the error bound. The supported compression methods are specified in `src/tersets.zig`. 
 
 Remember to free dynamically allocated memory appropriately to avoid memory leaks.
 </details>

--- a/README.md
+++ b/README.md
@@ -46,7 +46,11 @@ pub fn main() void {
 }
 ```
 
-TerseTS provides `./src/tersets.zig` as the single access point and two main functions `compress` and `decompress`. For compression, you can select the compression method through the `Configuration` structure with two parameters: the compression method, e.g., `.method=.SwingFilter`, and the error bound, e.g., `.error_bound = 0.1`. For decompression, the `Configuration` is not needed as the method is encoded in the compressed values.
+TerseTS provides `./src/tersets.zig` as the single access point and two main functions `compress` and `decompress`. 
+
+For compression, you can select the compression method through the `Configuration` structure with two parameters: the compression method, e.g., `.method=.SwingFilter`, and the error bound, e.g., `.error_bound = 0.1`. 
+
+For decompression, the `Configuration` is not needed as the method is encoded in the compressed values.
 </details>
 
 <a id="c-usage-example"></a>

--- a/README.md
+++ b/README.md
@@ -2,9 +2,12 @@
   <img src="docs/tersets.jpg" alt="TerseTS">
 </h1>
 
-TerseTS is a library that provides methods for lossless and lossy compressing time series. To match existing literature the methods are organized based on [Time Series Compression Survey](https://dl.acm.org/doi/10.1145/3560814). The library is implemented in Zig and provides a C-API with [bindings](#Installation) for other languages.
+TerseTS is a library that provides methods for lossless and lossy compressing time series. To match existing literature the methods are organized based on [Time Series Compression Survey](https://dl.acm.org/doi/10.1145/3560814). The library is implemented in Zig and provides a C-API with [bindings](#usage) for other languages.
 
-# Usage
+# Using TerseTS
+
+## Compilation
+
 TerseTS can be compiled and cross-compiled from source:
 1. Install the latest version of [Zig](https://ziglang.org/)
 2. Build TerseTS for development in `Debug` mode using Zig, e.g.,:
@@ -15,61 +18,60 @@ TerseTS can be compiled and cross-compiled from source:
    - Linux: `zig build -Dtarget=x86_64-linux -Doptimize=ReleaseFast`
    - macOS: `zig build -Dtarget=aarch64-macos -Doptimize=ReleaseFast`
    - Microsoft Windows: `zig build -Dtarget=x86_64-windows -Doptimize=ReleaseFast`
-4. Using TerseTS in Different Languages:
-   - TerseTS provides a C-API that is designed to be simple to wrap. Currently, TerseTS includes bindings for the following programming languages which can be used without installation of any dependencies.
-      - [Zig](src/tersets.zig). Check an example in [Zig Usage Example](#zig-usage-example).
-      - [C](bindings/c/tersets.h). Check an example in [C/C++ Usage Example](#c-usage-example).
-      - [C++](bindings/c/tersets.h). Check an example in [C/C++ Usage Example](#c-usage-example).
-      - [Python](bindings/python/tersets) using [ctypes](https://docs.python.org/3/library/ctypes.html). Check an example in [Python Usage Example](#python-usage-example).
+
+## Getting Started
+TerseTS provides a C-API that is designed to be simple to wrap. Currently, TerseTS includes bindings for the following programming languages which can be used without installation of any dependencies:
+-  [Zig Usage Example](#zig-usage-example)
+-  [C/C++ Usage Example](#c-usage-example)
+-  [Python Usage Example](#python-usage-example)
+
+<a id="zig-usage-example"></a>
 <details>
-<summary><strong>Zig</strong></summary>
+<summary><strong>Zig Usage Example</strong></summary>
 
-### Zig Usage Example
-
-
-```rust
+```c
 const std = @import("std");
 const tersets = @import("path/to/tersets.zig");
 
 pub fn main() void {
-    var data = [_]f64{1.0, 2.0, 3.0, 4.0, 5.0};
+    var uncompressed_values = [_]f64{1.0, 2.0, 3.0, 4.0, 5.0};
     const config = tersets.Configuration{
         .method = .SwingFilter,
-        .error_bound = 0.0,
+        .error_bound = 0.1,
     };
     
-    var compressed = try tersets.compress(data[0..], config);
+    var compressed_values = try tersets.compress(data[0..], config);
     defer std.heap.page_allocator.free(compressed);
 
-    var decompressed = try tersets.decompress(compressed, config);
+    var decompressed_values = try tersets.decompress(compressed, config);
     defer std.heap.page_allocator.free(decompressed);
 
-    std.debug.print("Decompression successful: {any}\n", .{decompressed});
+    std.debug.print("Decompression successful: {any}\n", .{decompressed_values.len});
 }
 ```
+
+TerseTS provides `./src/tersets.zig` as the single access point and two main functions `compress` and `decompress`. For compression, you can select the compression method through the `Configuration` structure with two parameters: the compression method, e.g., `.method=.SwingFilter`, and the error bound, e.g., `.error_bound = 0.1`. For decompression, the `Configuration` is not needed---the method is encoded in the compressed values.
 </details>
 
+<a id="c-usage-example"></a>
 <details>
-<summary><strong>C</strong></summary>
-
-### C Usage Example
+<summary><strong>C/C++ Usage Example</strong></summary>
 
 ```c 
 #include "tersets.h"
 #include <stdio.h>
 
 int main() {
-    // Example uncompressed data
-    double data[] = {1.0, 2.0, 3.0, 4.0, 5.0};
+    double uncompressed_values[] = {1.0, 2.0, 3.0, 4.0, 5.0};
     struct UncompressedValues uncompressed_values = {data, 5};
 
-    // Configuration for compression
-    struct Configuration config = {2, 0.0}; // Method 2 (e.g., SwingFilter), 0.0 error bound
+    // Configuration for compression.
+    struct Configuration config = {2, 0.0}; // Method 2 (e.g., SwingFilter), and 0.1 error bound.
 
-    // Prepare for compressed data
+    // Prepare for compressed data.
     struct CompressedValues compressed_values;
     
-    // Compress the data
+    // Compress the data.
     int32_t result = compress(uncompressed_values, &compressed_values, config);
     if (result != 0) {
         printf("Compression failed with error code %d\n", result);
@@ -78,10 +80,10 @@ int main() {
 
     printf("Compression successful. Compressed data length: %lu\n", compressed_values.len);
     
-    // Prepare for decompressed data
+    // Prepare for decompressed data.
     struct UncompressedValues decompressed_values;
    
-    // Decompress the data
+    // Decompress the data.
     int32_t result = decompress(compressed_values, &decompressed_values);
     if (result != 0) {
         printf("Decompression failed with error code %d\n", result);
@@ -96,46 +98,44 @@ int main() {
     return 0;
 }
 ```
-### Notes
-1. Include the Header and Link the Library.
-2. Add #include "tersets.h" in your source files and link the TerseTS library to your project.
-3. Ensure that the method field in `Configuration` is set to a valid compression/decompression method supported by `TerseTS`.
-4. Free dynamically allocated memory appropriately to avoid memory leaks.
+
+TerseTS provides `./bindings/c/tersets.h` as binding for C/C++, thus, the `#include "tersets.h"` in the source code. You need to link the TerseTS library to your project [linking](#linking).
+
+-  Ensure that the method field in `Configuration` is set to a valid compression/decompression method supported by `TerseTS`.
+
+-  Free dynamically allocated memory appropriately to avoid memory leaks.
 </details>
 
+<a id="python-usage-example"></a>
 <details>
-<summary><strong>Python</strong></summary>
-
-### Python Usage Example
+<summary><strong>Python Usage Example</strong></summary>
 
 ```python
 import random
 import sys
 from tersets import compress, decompress, Method
 
-# Number of values to generate for each test.
-TEST_VALUE_COUNT = 1000
+uncompressed_values = [1.0, 2.0, 3.0, 4.0, 5.0]
+error_bound = 0.1
 
-# Example Usage
+# Compress using the SwingFilter method.
+compressed_values = compress(uncompressed, 0.1, Method.SwingFilter)
 
-# Generate some random uncompressed data
-uncompressed = [random.uniform() for _ in range(TEST_VALUE_COUNT)]
+# Decompress the data
+decompressed = decompress(compressed_values)
 
-# Compress the data with zero error using the SwingFilter method
-compressed = compress(uncompressed, 0.0, Method.SwingFilter)
-
-# Decompress the data back to its original form
-decompressed = decompress(compressed)
-
-# Verify that the decompressed data matches the original data
-assert uncompressed == decompressed
-print("Compression and decompression were successful.")
+print("Decompression successful. Uncompressed data length: ", len(decompressed))
 ```
-### Notes
-   1. Modify the `__init__.py` file in the TerseTS Python bindings to link the correct shared library for your operating system. Specifically, change the `library_path` variable to reflect the path to TerseTS's library.
-   2. Import the necessary functions and classes from the TerseTS Python module.
+To use TerseTS from Python first ensure the `__init__.py` file in `binding/python/__init__.py` links the correct shared library. Specifically, change the `library_path` variable to reflect the path to TerseTS's library [linking](#linking). For example, in Windows: `library_path = path/to/tersets/zig-out/lib/tersets.dll`.
 
 </details>
+
+### Linking:
+
+* **For Windows:** Link the `tersets.dll` to your project. `tersets.dll` can be found in the output folder after compiling TersetTS, by default: `zig-out/lib/tersets.dll`.  
+
+* **For Linux:** Link the `tersets.so` to your project. `tersets.so` can be found in the output folder after compiling TersetTS, by default: `zig-out/lib/tersets.so`.
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ pub fn main() void {
 }
 ```
 
-TerseTS provides `./src/tersets.zig` as the single access point and two main functions `compress` and `decompress`. For compression, you can select the compression method through the `Configuration` structure with two parameters: the compression method, e.g., `.method=.SwingFilter`, and the error bound, e.g., `.error_bound = 0.1`. For decompression, the `Configuration` is not needed---the method is encoded in the compressed values.
+TerseTS provides `./src/tersets.zig` as the single access point and two main functions `compress` and `decompress`. For compression, you can select the compression method through the `Configuration` structure with two parameters: the compression method, e.g., `.method=.SwingFilter`, and the error bound, e.g., `.error_bound = 0.1`. For decompression, the `Configuration` is not needed as the method is encoded in the compressed values.
 </details>
 
 <a id="c-usage-example"></a>

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ print("Uncompressed data length: ", len(uncompressed_values))
 # The supported compression methods are specified in tersets.zig.
 # The Python-API provides a `Method` enum to access the available methods.
 # Compress the data.
-compressed_values = compress(uncompressed, error_bound, method)
+compressed_values = compress(uncompressed, method, error_bound)
 
 print("Compression successful. Compressed data length: ", len(compressed_values))
 
@@ -175,8 +175,8 @@ TerseTS provides `./bindings/python/tersets/__init__.py` as binding for Python w
 - **`compress()` Function:** 
    - **Parameters:**
       - `uncompressed_values`: The array of values to compress.
-      - `error_bound`: The error bound. 
       - `method`: The Python binding provides the `Method` enum to provide direct access to the available methods supported by `TerseTS`. The supported compression methods are specified in `src/tersets.zig`. 
+      - `error_bound`: The error bound. 
    - **Returns:** A list of compressed values.
 - **`decompress()` Function:** 
    - **Parameters:**

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ TerseTS can be compiled and cross-compiled from source:
    - Microsoft Windows: `zig build -Dtarget=x86_64-windows -Doptimize=ReleaseFast`
 
 ## Usage
-TerseTS provides a C-API that is designed to be simple to wrap. Currently, TerseTS includes API for the following programming languages which can be used without installation of any dependencies:
+TerseTS provides a C-API that is designed to be simple to wrap. Currently, TerseTS includes APIs for the following programming languages which can be used without installation of any dependencies:
 <a id="zig-usage-example"></a>
 <details>
 <summary><strong>Zig Usage Example</strong></summary>

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ TerseTS provides `./src/tersets.zig` as the single access point and two main fun
    - **Parameters:**
       - `uncompressed_values`: The array of values to compress.
       - `allocator`: Used to allocate memory for the returned `compressed_values` and other intermediate structures needed for compression.
-      - `method`: Compression method identifier based as specified in `tersets.Method`, e.g., `tersets.Method.SwingFilter`. The supported compression methods are specified in `src/tersets.zig`. 
+      - `method`: Compression method identifier as specified in `tersets.Method`, e.g., `tersets.Method.SwingFilter`. The supported compression methods are specified in `src/tersets.zig`. 
       - `error_bound`: An error bound of type `f32`. 
    - **Returns:** A dynamically allocated `compressed_values: ArrayList`, which must be deallocated with `deinit()`.
 - **`decompress()` Function:** 

--- a/README.md
+++ b/README.md
@@ -21,10 +21,6 @@ TerseTS can be compiled and cross-compiled from source:
 
 ## Getting Started
 TerseTS provides a C-API that is designed to be simple to wrap. Currently, TerseTS includes bindings for the following programming languages which can be used without installation of any dependencies:
--  [Zig Usage Example](#zig-usage-example)
--  [C/C++ Usage Example](#c-usage-example)
--  [Python Usage Example](#python-usage-example)
-
 <a id="zig-usage-example"></a>
 <details>
 <summary><strong>Zig Usage Example</strong></summary>

--- a/README.md
+++ b/README.md
@@ -56,9 +56,18 @@ pub fn main() void {
 
 TerseTS provides `./src/tersets.zig` as the single access point and two main functions `compress()` and `decompress()`. 
 
-The `compress()` function receives the `uncompressed_values`, a `allocator` to allocate memory for the returned `compressed_values` and other intermediate structures needed for compression, a compression method identification, e.g, `tersets.Method.SwingFilter` and error bound of type `f32`. The supported compression methods are specified in `src/tersets.zig`. 
-
-The `decompress()` function receives the `compressed_values` and a `allocator` to allocate memory for the returned `decompressed_values`.
+- **`compress()` Function:** 
+   - **Parameters:**
+      - `uncompressed_values`: The array of values to compress.
+      - `allocator`: Used to allocate memory for the returned `compressed_values` and other intermediate structures needed for compression.
+      - `method`: Compression method identifier based as specified in `tersets.Method`, e.g., `tersets.Method.SwingFilter`. The supported compression methods are specified in `src/tersets.zig`. 
+      - `error_bound`: An error bound of type `f32`. 
+   - **Returns:** A dynamically allocated `compressed_values: ArrayList`, which must be deallocated with `deinit()`.
+- **`decompress()` Function:** 
+   - **Parameters:**
+      - `compressed_values`: The compressed data to decompress.
+      - `allocator`: Used to allocate memory for the returned `decompressed_values`.
+   - **Returns:** A dynamically allocated `decompressed_values: ArrayList`, which must be deallocated with `deinit()`.   
 </details>
 
 <a id="c-usage-example"></a>
@@ -115,7 +124,17 @@ int main() {
 
 TerseTS provides `./bindings/c/tersets.h` as API for C which should be included in the source code, i.e., `#include "tersets.h"`. The TerseTS library must also be [linked](#linking) to the project. 
 
-The compression method can be selected through the `Configuration` structure with two parameters: the compression method, and the error bound. The supported compression methods are specified in `src/tersets.zig`. 
+- **`compress()` Function:** 
+   - **Parameters:**
+      - `uncompressed_values`: The array of values to compress.
+      - `compressed_values`: A pointer to a structure where the compressed values will be stored. The data is dynamically allocated.
+      - `config`: The configuration structure specifying the compression method and error bound. The supported compression methods are specified in `src/tersets.zig`. 
+   - **Returns:** An integer indicating success `(0)` or an error code.
+- **`decompress()` Function:** 
+   - **Parameters:**
+      - `compressed_values`: The compressed data to decompress.
+      - `decompressed_values`: A pointer to a structure where the decompressed values will be stored. The data is dynamically allocated.
+   - **Returns:** An integer indicating success `(0)` or an error code.
 
 Remember to free dynamically allocated memory appropriately to avoid memory leaks.
 </details>
@@ -130,6 +149,10 @@ import sys
 from tersets import compress, decompress, Method
 
 uncompressed_values = [1.0, 2.0, 3.0, 4.0, 5.0]
+
+# Configuration for compression. 
+# The supported compression methods are specified in tersets.zig.
+method = Method.SwingFilter
 error_bound = 0.1
 
 print("Uncompressed data length: ", len(uncompressed_values))
@@ -137,7 +160,7 @@ print("Uncompressed data length: ", len(uncompressed_values))
 # The supported compression methods are specified in tersets.zig.
 # The Python-API provides a `Method` enum to access the available methods.
 # Compress the data.
-compressed_values = compress(uncompressed, 0.1, Method.SwingFilter)
+compressed_values = compress(uncompressed, error_bound, method)
 
 print("Compression successful. Compressed data length: ", len(compressed_values))
 
@@ -149,7 +172,16 @@ print("Decompression successful. Decompressed data length: ", len(decompressed_v
 
 TerseTS provides `./bindings/python/tersets/__init__.py` as binding for Python which can be imported directly into a Python program with `import tersets`. The binding automatically loads the native library but assumes it is not moved.
 
-The Python binding provides the `Method` enum to provide direct access to the available methods supported by `TerseTS`.
+- **`compress()` Function:** 
+   - **Parameters:**
+      - `uncompressed_values`: The array of values to compress.
+      - `error_bound`: The error bound. 
+      - `method`: The Python binding provides the `Method` enum to provide direct access to the available methods supported by `TerseTS`. The supported compression methods are specified in `src/tersets.zig`. 
+   - **Returns:** A list of compressed values.
+- **`decompress()` Function:** 
+   - **Parameters:**
+      - `compressed_values`: The compressed data to decompress.
+   - **Returns:** A list of decompressed values.
 </details>
 
 ## Linking:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,113 @@ TerseTS can be compiled and cross-compiled from source:
    - Microsoft Windows: `zig build -Dtarget=x86_64-windows -Doptimize=ReleaseFast`
 
 # Usage
-TODO
+
+To use TerseTS in a C project, follow these steps:
+
+1. **Installation**:
+   - Ensure TerseTS is installed and compiled as per the installation instructions.
+
+2. **Linking**:
+   - For Windows: Link the `tersets.dll` to your project.
+   - For Linux: Link the `libtersets.so` to your project.
+   - Include the header file `tersets/bindings/c/tersets.h` in your project.
+
+3. **Include the Header**:
+   - Add `#include "tersets.h"` in your source files where you intend to use TerseTS functions. 
+
+4. **Compression and Decompression Interface**:
+   - Use the provided interface to compress and decompress time series data.
+
+### Example
+
+```c
+#include "tersets.h"
+#include <stdio.h>
+
+int main() {
+    // Example uncompressed data
+    double data[] = {1.0, 2.0, 3.0, 4.0, 5.0};
+    struct UncompressedValues uncompressed_values = {data, 5};
+
+    // Configuration for compression
+    struct Configuration config = {2, 0.0}; // Method 2 (e.g., SwingFilter), 0.0 error bound
+
+    // Prepare for compressed data
+    struct CompressedValues compressed_values;
+    
+    // Compress the data
+    int32_t result = compress(uncompressed_values, &compressed_values, config);
+    if (result != 0) {
+        printf("Compression failed with error code %d\n", result);
+        return -1;
+    }
+
+    printf("Compression successful. Compressed data length: %lu\n", compressed_values.len);
+    
+    // Prepare for decompressed data
+    struct UncompressedValues decompressed_values;
+   
+    // Decompress the data
+    int32_t result = decompress(compressed_values, &decompressed_values);
+    if (result != 0) {
+        printf("Decompression failed with error code %d\n", result);
+        return -1;
+    }
+
+    printf("Decompression successful. Uncompressed data length: %lu\n", decompressed_values.len);
+    
+    // Free the uncompressed data if dynamically allocated (not shown here)
+    // free(decompressed_values.data);
+    // free(compressed_values.data);
+    return 0;
+}
+```
+### Notes
+1. Ensure that the method field in `Configuration` is set to a valid compression/decompression method supported by `TerseTS`.
+2. Free dynamically allocated memory appropriately to avoid memory leaks.
+
+## Example Usage in Python
+
+To use TerseTS in a Python project, follow these steps:
+
+1. **Installation**:
+   - Ensure TerseTS is installed and compiled as per the installation instructions.
+   - Ensure the Python bindings in `tersets/bindings/python/tersets` are available in your project.
+
+2. **Linking the Library**:
+   - Modify the `__init__.py` file in the TerseTS Python bindings to link the correct shared library for your operating system. Specifically, change the `library_path` variable to reflect the path to TerseTS's library.
+
+3. **Import the Library**:
+   - Import the necessary functions and classes from the TerseTS Python module.
+
+4. **Compression and Decompression Interface**:
+    - Use the following interface to compress and decompress time series data.
+
+### Example
+```python
+import random
+import sys
+from tersets import compress, decompress, Method
+
+# Number of values to generate for each test.
+TEST_VALUE_COUNT = 1000
+
+# Example Usage
+
+# Generate some random uncompressed data
+uncompressed = [random.uniform() for _ in range(TEST_VALUE_COUNT)]
+
+# Compress the data with zero error using the SwingFilter method
+compressed = compress(uncompressed, 0.0, Method.SwingFilter)
+
+# Decompress the data back to its original form
+decompressed = decompress(compressed)
+
+# Verify that the decompressed data matches the original data
+assert uncompressed == decompressed
+print("Compression and decompression were successful.")
+```
+
 
 # Bindings
 TerseTS provides a C-API that is designed to be simple to wrap. Currently, TerseTS includes bindings for the following programming languages which can be used without installation of any dependencies:

--- a/bindings/python/tersets/__init__.py
+++ b/bindings/python/tersets/__init__.py
@@ -77,7 +77,7 @@ class Method(Enum):
 
 
 # Public Functions.
-def compress(values: List[float], error_bound: float, method: Method) -> bytes:
+def compress(values: List[float], method: Method, error_bound: float) -> bytes:
     """Compresses values."""
 
     uncompressed_values = __UncompressedValues()

--- a/bindings/python/tests/__init__.py
+++ b/bindings/python/tests/__init__.py
@@ -27,6 +27,6 @@ class TerseTSPythonTest(unittest.TestCase):
             random.uniform(sys.float_info.min, sys.float_info.max)
             for _ in range(0, TEST_VALUE_COUNT)
         ]
-        compressed = compress(uncompressed, 0.0, Method.SwingFilter)
+        compressed = compress(uncompressed, Method.SwingFilter, 0.0)
         decompressed = decompress(compressed)
         self.assertEqual(uncompressed, decompressed)


### PR DESCRIPTION
This PR fills the TODO in the Usage section of the Readme and Closes #18. An example of how to use TerseTS from C and Python is provided. 