### PR TITLE
Fix issues caused by new Zig releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+*.gch
+*.pch
 .idea
 .vscode
-zig-cache
-zig-out
-__pycache__
+.zig-cache
 TerseTS.egg-info
+__pycache__
 build
-*.gch
+zig-out

--- a/build.zig
+++ b/build.zig
@@ -22,7 +22,7 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const options = .{
         .name = "tersets",
-        .root_source_file = .{ .path = path },
+        .root_source_file = b.path(path),
         .target = target,
         .optimize = optimize,
         .version = .{ .major = 0, .minor = 0, .patch = 1 },


### PR DESCRIPTION
This PR fix two issues caused by Zig release 0.12.0 and 0.13.0. [Zig 0.12.0](https://ziglang.org/download/0.12.0/release-notes.html#introduce-bpath-deprecate-LazyPathrelative) introduces `b.path`, thus `build.zig` had to be updated as explained in the release notes. [Zig 0.13.0](https://ziglang.org/download/0.13.0/release-notes.html#codezig-cachecode-renamed-to-codezig-cachecode) changes the name of `zig-cache` to `.zig-cache`, thus `.gitignore` had to be updated. Also, while not related to the new releases of Zig, `*.pch` has been added to `.gitignore` so both GCC's and Clang's [precompiled headers](https://en.wikipedia.org/wiki/Precompiled_header) are ignored. Finally, the `.gitignore` file has been sorted so it is easier to find items.