### PR TITLE
Add support for python -m pip install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@
 .idea
 .vscode
 .zig-cache
-TerseTS.egg-info
+tersets.egg-info
 __pycache__
 build
 zig-out

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -7,7 +7,7 @@ The TerseTS Python package and native Zig library can be installed from source:
 2. Install the Python `setuptools` package:
    - `python -m pip install setuptools`
 3. Install the TerseTS Python package and native Zig library:
-   - `python -m install .`
+   - `python -m pip install .`
 
 ## Distribution
 The TerseTS Python package and native Zig library can be build from source:

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -2,11 +2,17 @@
 TerseTS is a library that provides native implementations of methods for lossless and lossy compressing time series in Zig. This package provides a Python interface for TerseTS. For more information about TerseTS, see the repositories main [README file](https://github.com/cmcuza/TerseTS/blob/main/README.md).
 
 ## Installation
-The TerseTS Python package and native Zig library can be build and install from source:
+The TerseTS Python package and native Zig library can be installed from source:
+1. Install the latest version of [Python](https://www.python.org/)
+2. Install the Python `setuptools` package:
+   - `python -m pip install setuptools`
+3. Install the TerseTS Python package and native Zig library:
+   - `python -m install .`
+
+## Distribution
+The TerseTS Python package and native Zig library can be build from source:
 1. Install the latest version of [Python](https://www.python.org/)
 2. Install the Python `build` and `setuptools` packages:
    - `python -m pip install build setuptools`
 2. Build the TerseTS Python package and native Zig library:
    - `python -m build`
-3. Install the TerseTS Python package and native Zig library:
-   - `pip install dist/tersets-cpython-platform-name.whl`


### PR DESCRIPTION
This PR finishes #52 by resolving the issues with `python -m pip install .` mentioned in the reviews of #61 in preparation for #62. The core issue solved by this PR is to copy `src` to the correct place and delete it afterwards no matter which order the `setuptools` commands are run in. This problem occurs because `python -m build` runs the `setuptools` commands `egg_info`, `sdist`, `egg_info`, `check`, `egg_info`, `bdist_wheel`, `build`, `build_py`, `egg_info`, and `build_ext` if `src` does not exist while  `python -m pip install .` runs the `setuptools` commands `bdist_wheel`, `build`, `build_py`, `egg_info`, and `build_ext` if `src` does not exist. Thus, both `sdist` and `bdist_wheel` have been extended to copy the `src` directory and then delete it again. In addition, checks have been added so `bdist_wheel` only copies the `src` directory if it is run in the repository and `src` does not already exist. As for #61, all methods for package installation should be tested on as many architectures and operating systems as possible.