### PR TITLE
Fix issues caused by new Zig release

### DIFF
--- a/.github/workflows/zig-build-lint-and-test-on-pr-and-push.yml
+++ b/.github/workflows/zig-build-lint-and-test-on-pr-and-push.yml
@@ -35,7 +35,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: goto-bus-stop/setup-zig@v2
       with:
-        version: 0.12.0  # Use a stable Zig version
+        version: 0.14.0  # Use a stable Zig version
 
     - name: Zig Build Debug
       run: zig build -Doptimize=Debug

--- a/bindings/python/tersets/__init__.py
+++ b/bindings/python/tersets/__init__.py
@@ -45,6 +45,7 @@ def __load_library():
     if sys.platform == "win32":
         # SHLIB_SUFFIX is not set and .dll is used by Zig.
         library_name = "tersets.dll"
+        library_folder = repository_root / "zig-out" / "bin"
     elif sys.platform == "darwin":
         # SHLIB_SUFFIX is set to .so but macOS uses .dylib.
         library_name = "tersets.dylib"

--- a/build.zig
+++ b/build.zig
@@ -17,23 +17,25 @@ const std = @import("std");
 pub fn build(b: *std.Build) void {
 
     // Configuration.
-    const path = "src/capi.zig";
+    const path = b.path("src/capi.zig");
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
-    const options = .{
-        .name = "tersets",
-        .root_source_file = b.path(path),
-        .target = target,
-        .optimize = optimize,
-        .version = .{ .major = 0, .minor = 0, .patch = 1 },
-    };
 
     // Task for compilation.
-    const lib = b.addSharedLibrary(options);
+    const lib = b.addSharedLibrary(.{
+        .name = "tersets",
+        .version = .{ .major = 0, .minor = 0, .patch = 1 },
+        .root_source_file = path,
+        .target = target,
+        .optimize = optimize,
+    });
     b.installArtifact(lib);
 
     // Task for running tests.
-    const tests = b.addTest(options);
+    const tests = b.addTest(.{
+        .root_source_file = path,
+        .optimize = optimize,
+    });
     const run_tests = b.addRunArtifact(tests);
     const test_step = b.step("test", "Run library tests");
     test_step.dependOn(&run_tests.step);

--- a/src/functional/histogram_compression.zig
+++ b/src/functional/histogram_compression.zig
@@ -565,7 +565,7 @@ test "Hash PriorityQueue with hash_context for MergeError" {
 test "Histogram insert, and merge test number buckets in PWCH" {
     // Initialize a random number generator.
     const seed: u64 = @bitCast(time.milliTimestamp());
-    var prng = std.rand.DefaultPrng.init(seed);
+    var prng = std.Random.DefaultPrng.init(seed);
     const random = prng.random();
 
     const allocator = testing.allocator;
@@ -625,7 +625,7 @@ test "Simple fixed values test of PWCH" {
 test "Fixed cluster number with random values for PWCH" {
     // Initialize a random number generator.
     const seed: u64 = @bitCast(time.milliTimestamp());
-    var prng = std.rand.DefaultPrng.init(seed);
+    var prng = std.Random.DefaultPrng.init(seed);
     const random = prng.random();
 
     const allocator = std.testing.allocator;
@@ -653,7 +653,7 @@ test "Fixed cluster number with random values for PWCH" {
 
     // Generate random values for each cluster.
     for (cluster_ranges) |cluster| {
-        for (cluster.count) |_| {
+        for (0..cluster.count) |_| {
             const value = tester.generateBoundedRandomValue(cluster.min, cluster.max, random);
             try data_points.append(value);
         }
@@ -699,7 +699,7 @@ test "Fixed cluster number with random values for PWCH" {
 
 test "Random clusters, elements per cluster and values for PWCH" {
     // Initialize a random number generator.
-    var prng = std.rand.DefaultPrng.init(12345);
+    var prng = std.Random.DefaultPrng.init(12345);
     const random = prng.random();
 
     const allocator = std.testing.allocator;
@@ -739,7 +739,7 @@ test "Random clusters, elements per cluster and values for PWCH" {
 
     // Generate random values for each cluster.
     for (cluster_ranges.items) |cluster| {
-        for (cluster.count) |_| {
+        for (0..cluster.count) |_| {
             const value = tester.generateBoundedRandomValue(cluster.min, cluster.max, random);
             try data_points.append(value);
         }
@@ -784,7 +784,7 @@ test "Random clusters, elements per cluster and values for PWCH" {
 }
 
 test "PWCH can compress and decompress with bounded values and expected maximum error" {
-    var prng = std.rand.DefaultPrng.init(0);
+    var prng = std.Random.DefaultPrng.init(0);
     const random = prng.random();
     const error_bound: f32 = 10;
 
@@ -914,7 +914,7 @@ test "Compute PWLH with a simple set of values with known results" {
 }
 
 test "Insert random values in an Histogram with expected number of buckets" {
-    var prng = std.rand.DefaultPrng.init(0);
+    var prng = std.Random.DefaultPrng.init(0);
     const random = prng.random();
 
     const allocator = testing.allocator;
@@ -931,7 +931,7 @@ test "Insert random values in an Histogram with expected number of buckets" {
 }
 
 test "PWLH can compress and decompress with bounded values and expected maximum error" {
-    var prng = std.rand.DefaultPrng.init(0);
+    var prng = std.Random.DefaultPrng.init(0);
     const random = prng.random();
     const error_bound: f32 = 10;
 

--- a/src/functional/sim_piece.zig
+++ b/src/functional/sim_piece.zig
@@ -23,7 +23,7 @@
 const std = @import("std");
 const math = std.math;
 const mem = std.mem;
-const rand = std.rand;
+const rand = std.Random;
 const time = std.time;
 const testing = std.testing;
 const ArrayList = std.ArrayList;
@@ -547,7 +547,7 @@ test "f64 context can hash" {
         std.hash_map.default_max_load_percentage,
     ).init(allocator);
     defer f64_hash_map.deinit();
-    var rnd = std.rand.DefaultPrng.init(@as(u64, @bitCast(std.time.milliTimestamp())));
+    var rnd = std.Random.DefaultPrng.init(@as(u64, @bitCast(std.time.milliTimestamp())));
 
     // Add 100 elements into the HashMap. For each element, add two more with small deviation of
     // 1e-16 to test that the numbers are different and a new key is created.
@@ -585,7 +585,7 @@ test "hashmap can map f64 to segment metadata array list" {
     var f64_usize_hash_map = HashMapf64(usize).init(allocator);
     defer f64_usize_hash_map.deinit();
 
-    var rnd = std.rand.DefaultPrng.init(@as(u64, @bitCast(std.time.milliTimestamp())));
+    var rnd = std.Random.DefaultPrng.init(@as(u64, @bitCast(std.time.milliTimestamp())));
 
     for (0..200) |_| {
         const rand_number = @floor((rnd.random().float(f64) - 0.5) * 100) / 10;

--- a/src/functional/swing_slide_filter.zig
+++ b/src/functional/swing_slide_filter.zig
@@ -293,7 +293,7 @@ pub fn compressSlide(
             // crosses the interception point of the upper and lower bounds.
             computeInterceptionPoint(lower_bound, upper_bound, &intercept_point);
 
-            const current_linear_approximation = .{
+            const current_linear_approximation = LinearFunction{
                 .slope = (lower_bound.slope + upper_bound.slope) / 2,
                 .intercept = computeInterceptCoefficient(
                     (lower_bound.slope + upper_bound.slope) / 2,
@@ -395,7 +395,7 @@ pub fn compressSlide(
 
     if (segment_size > 1) {
         computeInterceptionPoint(lower_bound, upper_bound, &intercept_point);
-        const linear_approximation = .{
+        const linear_approximation = LinearFunction{
             .slope = (lower_bound.slope + upper_bound.slope) / 2,
             .intercept = computeInterceptCoefficient(
                 (lower_bound.slope + upper_bound.slope) / 2,
@@ -591,7 +591,7 @@ test "swing filter zero error bound and even size compress and decompress" {
     defer decompressed_values.deinit();
     const error_bound: f32 = 0.0;
 
-    var rnd = std.rand.DefaultPrng.init(0);
+    var rnd = std.Random.DefaultPrng.init(0);
 
     var i: usize = 0;
     while (i < 100) : (i += 1) {
@@ -624,7 +624,7 @@ test "swing filter zero error bound and odd size compress and decompress" {
     defer decompressed_values.deinit();
     const error_bound: f32 = 0.0;
 
-    var rnd = std.rand.DefaultPrng.init(0);
+    var rnd = std.Random.DefaultPrng.init(0);
 
     var i: usize = 0;
     while (i < 101) : (i += 1) {
@@ -646,7 +646,7 @@ test "swing filter zero error bound and odd size compress and decompress" {
 
 test "swing filter four random lines and random error bound compress and decompress" {
     const allocator = testing.allocator;
-    var rnd = std.rand.DefaultPrng.init(@as(u64, @bitCast(std.time.milliTimestamp())));
+    var rnd = std.Random.DefaultPrng.init(@as(u64, @bitCast(std.time.milliTimestamp())));
 
     const linear_functions = [_]LinearFunction{
         LinearFunction{
@@ -711,7 +711,7 @@ test "slide filter zero error bound and even size compress and decompress" {
     defer decompressed_values.deinit();
     const error_bound: f32 = 0.0;
 
-    var rnd = std.rand.DefaultPrng.init(@as(u64, @bitCast(std.time.milliTimestamp())));
+    var rnd = std.Random.DefaultPrng.init(@as(u64, @bitCast(std.time.milliTimestamp())));
 
     var i: usize = 0;
     while (i < 100) : (i += 1) {
@@ -749,7 +749,7 @@ test "slide filter zero error bound and odd size compress and decompress" {
     defer decompressed_values.deinit();
     const error_bound: f32 = 0.0;
 
-    var rnd = std.rand.DefaultPrng.init(0);
+    var rnd = std.Random.DefaultPrng.init(0);
 
     var i: usize = 0;
     while (i < 101) : (i += 1) {
@@ -776,7 +776,7 @@ test "slide filter zero error bound and odd size compress and decompress" {
 
 test "slide filter four random lines and random error bound compress and decompress" {
     const allocator = testing.allocator;
-    var rnd = std.rand.DefaultPrng.init(@as(u64, @bitCast(std.time.milliTimestamp())));
+    var rnd = std.Random.DefaultPrng.init(@as(u64, @bitCast(std.time.milliTimestamp())));
 
     const linear_functions = [_]LinearFunction{
         LinearFunction{

--- a/src/tersets.zig
+++ b/src/tersets.zig
@@ -179,7 +179,7 @@ pub fn isWithinErrorBound(
 
 /// Get the maximum index of the available methods in TerseTS.
 pub fn getMaxMethodIndex() usize {
-    const method_info = @typeInfo(Method).Enum;
+    const method_info = @typeInfo(Method).@"enum";
 
     var max_index: usize = 0;
     for (method_info.fields, 0..) |_, i| {

--- a/src/tester.zig
+++ b/src/tester.zig
@@ -16,8 +16,7 @@
 
 const std = @import("std");
 const ArrayList = std.ArrayList;
-const rand = std.rand;
-const Random = rand.Random;
+const Random = std.Random;
 const Allocator = std.mem.Allocator;
 const Error = std.mem.Allocator.Error;
 const math = std.math;
@@ -51,7 +50,7 @@ pub fn testGenerateCompressAndDecompress(
     ) bool,
 ) !void {
     const seed: u64 = @bitCast(time.milliTimestamp());
-    var prng = rand.DefaultPrng.init(seed);
+    var prng = Random.DefaultPrng.init(seed);
     const random = prng.random();
 
     var uncompressed_values = ArrayList(f64).init(allocator);
@@ -69,8 +68,8 @@ pub fn testGenerateCompressAndDecompress(
 
     while (subsequenceStack.items.len != 0) {
         // subsequenceStack contains start and end as separate integers of usize.
-        const end = subsequenceStack.pop();
-        const start = subsequenceStack.pop();
+        const end = subsequenceStack.pop().?;
+        const start = subsequenceStack.pop().?;
         const uncompressed_values_subsequence = uncompressed_values.items[start..end];
 
         testCompressAndDecompress(
@@ -181,7 +180,7 @@ pub fn replaceNormalValues(
 pub fn generateRandomValues(uncompressed_values: *ArrayList(f64), random: Random) !void {
     for (0..number_of_values) |_| {
         // rand can only generate f64 values in the range [0, 1).
-        try uncompressed_values.append(@as(f64, @bitCast(rand.int(random, u64))));
+        try uncompressed_values.append(@as(f64, @bitCast(random.int(u64))));
     }
 }
 

--- a/src/utilities/convex_hull.zig
+++ b/src/utilities/convex_hull.zig
@@ -569,7 +569,7 @@ test "Create incrementally convex hull with known result" {
 
 test "Create incrementally a convex hull with random elements" {
     const allocator = testing.allocator;
-    var rnd = std.rand.DefaultPrng.init(0);
+    var rnd = std.Random.DefaultPrng.init(0);
 
     var convex_hull = try ConvexHull.init(allocator);
     defer convex_hull.deinit();
@@ -638,7 +638,7 @@ test "Compute MABR LinearFunction for known Convex Hull two" {
 
 test "Compute MABR LinearFunction for random Convex Hull" {
     const allocator = testing.allocator;
-    var rnd = std.rand.DefaultPrng.init(0);
+    var rnd = std.Random.DefaultPrng.init(0);
 
     var convex_hull = try ConvexHull.init(allocator);
     defer convex_hull.deinit();
@@ -721,7 +721,7 @@ test "Merge not-in-place convex hulls with random elements" {
 
 test "Merge in-place single element's convex hull with other convex hull" {
     const allocator = testing.allocator;
-    var rnd = std.rand.DefaultPrng.init(0);
+    var rnd = std.Random.DefaultPrng.init(0);
 
     var convex_hull_one = try ConvexHull.init(allocator);
     defer convex_hull_one.deinit();
@@ -742,7 +742,7 @@ test "Merge in-place single element's convex hull with other convex hull" {
 
 test "Merge not-in-place single element's convex hull with other convex hull" {
     const allocator = testing.allocator;
-    var rnd = std.rand.DefaultPrng.init(0);
+    var rnd = std.Random.DefaultPrng.init(0);
 
     var convex_hull_one = try ConvexHull.init(allocator);
     defer convex_hull_one.deinit();
@@ -766,7 +766,7 @@ test "Merge not-in-place single element's convex hull with other convex hull" {
 
 test "Merge in-place convex hull with single element's convex hull" {
     const allocator = testing.allocator;
-    var rnd = std.rand.DefaultPrng.init(0);
+    var rnd = std.Random.DefaultPrng.init(0);
 
     var convex_hull_one = try ConvexHull.init(allocator);
     defer convex_hull_one.deinit();
@@ -787,7 +787,7 @@ test "Merge in-place convex hull with single element's convex hull" {
 
 test "Merge not-in-place convex hull with single element's convex hull" {
     const allocator = testing.allocator;
-    var rnd = std.rand.DefaultPrng.init(0);
+    var rnd = std.Random.DefaultPrng.init(0);
 
     var convex_hull_one = try ConvexHull.init(allocator);
     defer convex_hull_one.deinit();
@@ -811,7 +811,7 @@ test "Merge not-in-place convex hull with single element's convex hull" {
 
 test "Merge not-in-place does not modify the convex hulls one and two" {
     const allocator = testing.allocator;
-    var rnd = std.rand.DefaultPrng.init(0);
+    var rnd = std.Random.DefaultPrng.init(0);
 
     // Initialize convex_hull_one.
     var convex_hull_one = try ConvexHull.init(allocator);
@@ -886,7 +886,7 @@ test "Compute max error with known points and linear function" {
 
 test "Compute max error with random points and linear function" {
     const allocator = testing.allocator;
-    var rnd = std.rand.DefaultPrng.init(0);
+    var rnd = std.Random.DefaultPrng.init(0);
 
     var convex_hull = try ConvexHull.init(allocator);
     defer convex_hull.deinit();
@@ -953,7 +953,7 @@ fn testConvexHullProperty(convex_hull: *ConvexHull) !void {
 /// flag. After merging, it validates the properties of the resulting convex hull.
 fn mergeConvexHullsTestHelper(in_place: bool) !void {
     const allocator = testing.allocator;
-    var rnd = std.rand.DefaultPrng.init(0);
+    var rnd = std.Random.DefaultPrng.init(0);
 
     // Initialize the first convex hull with random points.
     var convex_hull_one = try ConvexHull.init(allocator);

--- a/src/utilities/hashed_priority_queue.zig
+++ b/src/utilities/hashed_priority_queue.zig
@@ -22,7 +22,7 @@
 //! priority of elements change, or where elements need to be accessed by key.
 
 const std = @import("std");
-const rand = std.rand;
+const rand = std.Random;
 const math = std.math;
 const time = std.time;
 const Order = std.math.Order;
@@ -269,7 +269,7 @@ test "add and remove min keys of simple values in HashedPriorityQueue" {
 
     // Initialize a random number generator.
     const seed: u64 = @bitCast(time.milliTimestamp());
-    var rnd = std.rand.DefaultPrng.init(seed);
+    var rnd = std.Random.DefaultPrng.init(seed);
 
     for (0..100) |_| {
         // Generate a random i64 value


### PR DESCRIPTION
This PR fixes two issues caused by Zig release 0.14.0. First, [Zig 0.14.0](https://ziglang.org/download/0.14.0/release-notes.html#Remove-Anonymous-Struct-Types-Unify-Tuples) changes the type of "untyped anonymous struct literals" such as `const x = .{ .a = 123 }` from "anonymous struct type" to "normal struct type". Second, [Zig 0.14.0](https://ziglang.org/download/0.14.0/release-notes.html#List-of-Deprecations) `std.rand` has been renamed to `std.Random`.