### PR TITLE
Fix Swing Filter Implementation

### DIFF
--- a/bindings/python/tersets/__init__.py
+++ b/bindings/python/tersets/__init__.py
@@ -77,13 +77,13 @@ class __Configuration(Structure):
 @unique
 class Method(Enum):
     PoorMansCompressionMidrange = 0
-    PoorMansCompressionMean = 1,
-    SwingFilter = 2,
-    SwingFilterDisconnected = 3,
-    SlideFilter = 4,
-    SimPiece = 5,
-    PiecewiseConstantHistogram = 6,
-    PiecewiseLinearHistogram = 7,
+    PoorMansCompressionMean = 1
+    SwingFilter = 2
+    SwingFilterDisconnected = 3
+    SlideFilter = 4
+    SimPiece = 5
+    PiecewiseConstantHistogram = 6
+    PiecewiseLinearHistogram = 7
     
 
 # Public Functions.

--- a/bindings/python/tersets/__init__.py
+++ b/bindings/python/tersets/__init__.py
@@ -77,9 +77,14 @@ class __Configuration(Structure):
 @unique
 class Method(Enum):
     PoorMansCompressionMidrange = 0
-    PoorMansCompressionMean = 1
-    SwingFilter = 2
-
+    PoorMansCompressionMean = 1,
+    SwingFilter = 2,
+    SwingFilterDisconnected = 3,
+    SlideFilter = 4,
+    SimPiece = 5,
+    PiecewiseConstantHistogram = 6,
+    PiecewiseLinearHistogram = 7,
+    
 
 # Public Functions.
 def compress(values: List[float], method: Method, error_bound: float) -> bytes:

--- a/src/capi.zig
+++ b/src/capi.zig
@@ -114,10 +114,11 @@ test "method enum must match method constants" {
     try testing.expectEqual(@intFromEnum(tersets.Method.PoorMansCompressionMidrange), 0);
     try testing.expectEqual(@intFromEnum(tersets.Method.PoorMansCompressionMean), 1);
     try testing.expectEqual(@intFromEnum(tersets.Method.SwingFilter), 2);
-    try testing.expectEqual(@intFromEnum(tersets.Method.SlideFilter), 3);
-    try testing.expectEqual(@intFromEnum(tersets.Method.SimPiece), 4);
-    try testing.expectEqual(@intFromEnum(tersets.Method.PiecewiseConstantHistogram), 5);
-    try testing.expectEqual(@intFromEnum(tersets.Method.PiecewiseLinearHistogram), 6);
+    try testing.expectEqual(@intFromEnum(tersets.Method.SwingFilterDisconnected), 3);
+    try testing.expectEqual(@intFromEnum(tersets.Method.SlideFilter), 4);
+    try testing.expectEqual(@intFromEnum(tersets.Method.SimPiece), 5);
+    try testing.expectEqual(@intFromEnum(tersets.Method.PiecewiseConstantHistogram), 6);
+    try testing.expectEqual(@intFromEnum(tersets.Method.PiecewiseLinearHistogram), 7);
 }
 
 test "error for unknown compression method" {

--- a/src/functional/histogram_compression.zig
+++ b/src/functional/histogram_compression.zig
@@ -575,7 +575,7 @@ test "Histogram insert, and merge test number buckets in PWCH" {
 
     // Insert 1000 random numbers into the histogram.
     for (0..1000) |i| {
-        const rand_number = tester.generateBoundedRandomValue(0, 1000, random);
+        const rand_number = tester.generateBoundedRandomValue(f64, 0, 1000, random);
         try histogram.insert(i, rand_number);
     }
     try expectEqual(max_buckets, histogram.buckets.items.len);
@@ -654,7 +654,7 @@ test "Fixed cluster number with random values for PWCH" {
     // Generate random values for each cluster.
     for (cluster_ranges) |cluster| {
         for (0..cluster.count) |_| {
-            const value = tester.generateBoundedRandomValue(cluster.min, cluster.max, random);
+            const value = tester.generateBoundedRandomValue(f64, cluster.min, cluster.max, random);
             try data_points.append(value);
         }
     }
@@ -713,9 +713,9 @@ test "Random clusters, elements per cluster and values for PWCH" {
     defer cluster_ranges.deinit();
 
     const min_value: f64 = -1e6;
-    const cluster_width: f64 = tester.generateBoundedRandomValue(100, 1000, random);
+    const cluster_width: f64 = tester.generateBoundedRandomValue(f64, 100, 1000, random);
     // Generate min gap.
-    const gap: f64 = cluster_width + tester.generateBoundedRandomValue(100, 1000, random) + 100;
+    const gap: f64 = cluster_width + tester.generateBoundedRandomValue(f64, 100, 1000, random) + 100;
     const max_counts_per_cluster: usize = 100;
 
     var current_min_value = min_value;
@@ -740,7 +740,7 @@ test "Random clusters, elements per cluster and values for PWCH" {
     // Generate random values for each cluster.
     for (cluster_ranges.items) |cluster| {
         for (0..cluster.count) |_| {
-            const value = tester.generateBoundedRandomValue(cluster.min, cluster.max, random);
+            const value = tester.generateBoundedRandomValue(f64, cluster.min, cluster.max, random);
             try data_points.append(value);
         }
     }
@@ -924,7 +924,7 @@ test "Insert random values in an Histogram with expected number of buckets" {
 
     // Insert 1000 random numbers into the histogram.
     for (0..1000) |i| {
-        const rand_number = tester.generateBoundedRandomValue(0, 1000, random);
+        const rand_number = tester.generateBoundedRandomValue(f64, 0, 1000, random);
         try histogram.insert(i, rand_number);
     }
     try expectEqual(max_buckets, histogram.buckets.items.len);

--- a/src/functional/swing_slide_filter.zig
+++ b/src/functional/swing_slide_filter.zig
@@ -51,7 +51,7 @@ const ConvexHull = @import("../utilities/convex_hull.zig").ConvexHull;
 
 /// Compress `uncompressed_values` within `error_bound` using "Swing Filter" and write the
 /// result to `compressed_values`. If an error occurs it is returned.
-pub fn compressSwing(
+pub fn compressSwingFilter(
     uncompressed_values: []const f64,
     compressed_values: *ArrayList(u8),
     error_bound: f32,
@@ -83,18 +83,19 @@ pub fn compressSwing(
     updateSwingLinearFunction(current_segment, &upper_bound, adjusted_error_bound);
     updateSwingLinearFunction(current_segment, &lower_bound, -adjusted_error_bound);
 
+    try appendValue(f64, current_segment.start_point.value, compressed_values);
+
     // The first two points are already part of `current_segment`, the next point is at index two.
     var current_timestamp: usize = 2;
     while (current_timestamp < uncompressed_values.len) : (current_timestamp += 1) {
         // Evaluate the upper and lower bound linear functions at the current timestamp.
         const upper_limit = evaluateLinearFunctionAtTime(upper_bound, usize, current_timestamp);
         const lower_limit = evaluateLinearFunctionAtTime(lower_bound, usize, current_timestamp);
-
+        var end_value: f64 = 0;
         if ((upper_limit < (uncompressed_values[current_timestamp] - adjusted_error_bound)) or
             (lower_limit > (uncompressed_values[current_timestamp] + adjusted_error_bound)))
         {
             // Recording mechanism (the current points is outside the limits).
-            try appendValue(f64, current_segment.start_point.value, compressed_values);
             const segment_size = current_timestamp - current_segment.start_point.time - 1;
             if (segment_size > 1) {
                 // Denominator of Eq. (6).
@@ -116,31 +117,33 @@ pub fn compressSwing(
                         current_segment.start_point,
                     ),
                 };
-                const end_value = evaluateLinearFunctionAtTime(linear_approximation, usize, current_timestamp - 1);
+
+                end_value = evaluateLinearFunctionAtTime(linear_approximation, usize, current_timestamp - 1);
 
                 try appendValue(f64, end_value, compressed_values);
             } else {
                 // Storing uncompressed values instead of those from the linear approximation is crucial
                 // for numerical stability, particularly when the error bound is zero. In such cases,
                 // decompression must be lossless, and even minimal approximation errors are unacceptable.
+                end_value = current_segment.end_point.value;
                 try appendValue(f64, current_segment.end_point.value, compressed_values);
             }
 
             try appendValue(usize, current_timestamp, compressed_values);
 
             // Update the current segment.
-            current_segment.start_point.time = current_timestamp;
-            current_segment.start_point.value = uncompressed_values[current_timestamp];
+            current_segment.start_point.time = current_timestamp - 1;
+            current_segment.start_point.value = end_value;
 
             // Edge case as only one point is left.
-            if (current_timestamp + 1 < uncompressed_values.len) {
-                current_segment.end_point.time = current_timestamp + 1;
-                current_segment.end_point.value = uncompressed_values[current_timestamp + 1];
+            if (current_timestamp < uncompressed_values.len) {
+                current_segment.end_point.time = current_timestamp;
+                current_segment.end_point.value = uncompressed_values[current_timestamp];
 
                 updateSwingLinearFunction(current_segment, &upper_bound, adjusted_error_bound);
                 updateSwingLinearFunction(current_segment, &lower_bound, -adjusted_error_bound);
 
-                current_timestamp += 1;
+                // current_timestamp += 1;
                 slope_derivate = computeSlopeDerivate(current_segment);
             } else {
                 // Only one point left. The `end_point` is at the `current_timestamp`.
@@ -184,7 +187,7 @@ pub fn compressSwing(
 
     const segment_size = current_timestamp - current_segment.start_point.time - 1;
 
-    try appendValue(f64, current_segment.start_point.value, compressed_values);
+    // try appendValue(f64, current_segment.start_point.value, compressed_values);
     if (segment_size > 1) {
         // Denominator of Eq. (6).
         const sum_square: f80 = @floatFromInt(
@@ -222,7 +225,7 @@ pub fn compressSwing(
 /// Compress `uncompressed_values` within `error_bound` using "Slide Filter" and write the
 /// result to `compressed_values`. The `allocator` is used to allocate memory for the convex hull.
 /// If an error occurs it is returned.
-pub fn compressSlide(
+pub fn compressSlideFilter(
     uncompressed_values: []const f64,
     compressed_values: *ArrayList(u8),
     allocator: mem.Allocator,
@@ -426,9 +429,232 @@ pub fn compressSlide(
     try appendValue(usize, current_timestamp, compressed_values);
 }
 
-/// Decompress `compressed_values` produced by "Swing Filter" and "Slide Filter" and write the
-/// result to `decompressed_values`. If an error occurs it is returned.
-pub fn decompress(
+/// Compress `uncompressed_values` within `error_bound` using "Swing Filter"'s filtering mechanism.
+/// Different from the proposed papper, this implementation allows a extra degree of freedom by
+/// disconnecting adjacent segments in the recording mechanism. The algorithm write the result to
+/// `compressed_values`. If an error occurs it is returned.
+pub fn compressSwingFilterDisconnected(
+    uncompressed_values: []const f64,
+    compressed_values: *ArrayList(u8),
+    error_bound: f32,
+) !void {
+    // Adjust the error bound to avoid exceeding it during decompression due to numerical
+    // inestabilities. This can happen if the linear approximation is equal to one of the
+    // upper or lower bounds.
+    const adjusted_error_bound = if (error_bound > 0)
+        error_bound - shared.ErrorBoundMargin
+    else
+        error_bound;
+
+    // Initialize the linear function used across the method. Their values will be defined as part
+    // of the method logic, thus now are undefined.
+    var upper_bound: LinearFunction = .{ .slope = undefined, .intercept = undefined };
+    var lower_bound: LinearFunction = .{ .slope = undefined, .intercept = undefined };
+    var new_upper_bound: LinearFunction = .{ .slope = undefined, .intercept = undefined };
+    var new_lower_bound: LinearFunction = .{ .slope = undefined, .intercept = undefined };
+
+    // Initialize the current segment with first two points.
+    var current_segment: Segment = .{
+        .start_point = .{ .time = 0, .value = uncompressed_values[0] },
+        .end_point = .{ .time = 1, .value = uncompressed_values[1] },
+    };
+
+    // Compute the numerator Eq. (6).
+    var slope_derivate: f80 = computeSlopeDerivate(current_segment);
+
+    updateSwingLinearFunction(current_segment, &upper_bound, adjusted_error_bound);
+    updateSwingLinearFunction(current_segment, &lower_bound, -adjusted_error_bound);
+
+    // The first two points are already part of `current_segment`, the next point is at index two.
+    var current_timestamp: usize = 2;
+    while (current_timestamp < uncompressed_values.len) : (current_timestamp += 1) {
+        // Evaluate the upper and lower bound linear functions at the current timestamp.
+        const upper_limit = evaluateLinearFunctionAtTime(upper_bound, usize, current_timestamp);
+        const lower_limit = evaluateLinearFunctionAtTime(lower_bound, usize, current_timestamp);
+
+        if ((upper_limit < (uncompressed_values[current_timestamp] - adjusted_error_bound)) or
+            (lower_limit > (uncompressed_values[current_timestamp] + adjusted_error_bound)))
+        {
+            // Recording mechanism (the current points is outside the limits).
+            try appendValue(f64, current_segment.start_point.value, compressed_values);
+            const segment_size = current_timestamp - current_segment.start_point.time - 1;
+            if (segment_size > 1) {
+                // Denominator of Eq. (6).
+                const sum_square: f80 = @floatFromInt(
+                    segment_size * (segment_size + 1) * (2 * segment_size + 1) / 6,
+                );
+
+                // Get optimal slope that minimizes the squared error Eq. (5).
+                const slope: f80 = @max(
+                    @min(slope_derivate / sum_square, upper_bound.slope),
+                    lower_bound.slope,
+                );
+
+                const linear_approximation: LinearFunction = .{
+                    .slope = slope,
+                    .intercept = computeInterceptCoefficient(
+                        slope,
+                        DiscretePoint,
+                        current_segment.start_point,
+                    ),
+                };
+                const end_value = evaluateLinearFunctionAtTime(linear_approximation, usize, current_timestamp - 1);
+
+                try appendValue(f64, end_value, compressed_values);
+            } else {
+                // Storing uncompressed values instead of those from the linear approximation is crucial
+                // for numerical stability, particularly when the error bound is zero. In such cases,
+                // decompression must be lossless, and even minimal approximation errors are unacceptable.
+                try appendValue(f64, current_segment.end_point.value, compressed_values);
+            }
+
+            try appendValue(usize, current_timestamp, compressed_values);
+
+            // Update the current segment.
+            current_segment.start_point.time = current_timestamp;
+            current_segment.start_point.value = uncompressed_values[current_timestamp];
+
+            // Edge case as only one point is left.
+            if (current_timestamp + 1 < uncompressed_values.len) {
+                current_segment.end_point.time = current_timestamp + 1;
+                current_segment.end_point.value = uncompressed_values[current_timestamp + 1];
+
+                updateSwingLinearFunction(current_segment, &upper_bound, adjusted_error_bound);
+                updateSwingLinearFunction(current_segment, &lower_bound, -adjusted_error_bound);
+
+                current_timestamp += 1;
+                slope_derivate = computeSlopeDerivate(current_segment);
+            } else {
+                // Only one point left. The `end_point` is at the `current_timestamp`.
+                current_segment.end_point.time = current_timestamp;
+                current_segment.end_point.value = uncompressed_values[current_timestamp];
+            }
+        } else {
+            //Filtering mechanism (the current point is still inside the limits).
+            current_segment.end_point.time = current_timestamp;
+            current_segment.end_point.value = uncompressed_values[current_timestamp];
+
+            // Update the potentially new upper and lower bounds with the new current point.
+            updateSwingLinearFunction(current_segment, &new_upper_bound, adjusted_error_bound);
+            updateSwingLinearFunction(current_segment, &new_lower_bound, -adjusted_error_bound);
+
+            const new_upper_limit: f80 = evaluateLinearFunctionAtTime(
+                new_upper_bound,
+                usize,
+                current_timestamp,
+            );
+            const new_lower_limit: f80 = evaluateLinearFunctionAtTime(
+                new_lower_bound,
+                usize,
+                current_timestamp,
+            );
+
+            // Update the upper and lower bounds if needed.
+            if (upper_limit > new_upper_limit) {
+                // Swing down.
+                upper_bound = new_upper_bound;
+            }
+            if (lower_limit < new_lower_limit) {
+                //Swing up.
+                lower_bound = new_lower_bound;
+            }
+
+            // Update slope derivate.
+            slope_derivate += computeSlopeDerivate(current_segment);
+        }
+    }
+
+    const segment_size = current_timestamp - current_segment.start_point.time - 1;
+
+    try appendValue(f64, current_segment.start_point.value, compressed_values);
+    if (segment_size > 1) {
+        // Denominator of Eq. (6).
+        const sum_square: f80 = @floatFromInt(
+            segment_size * (segment_size + 1) * (2 * segment_size + 1) / 6,
+        );
+
+        // Get optimal slope that minimizes the squared error Eq. (5).
+        const slope: f80 = @max(
+            @min(slope_derivate / sum_square, upper_bound.slope),
+            lower_bound.slope,
+        );
+
+        const linear_approximation: LinearFunction = .{
+            .slope = slope,
+            .intercept = computeInterceptCoefficient(
+                slope,
+                DiscretePoint,
+                current_segment.start_point,
+            ),
+        };
+
+        const end_value: f64 = evaluateLinearFunctionAtTime(
+            linear_approximation,
+            usize,
+            current_timestamp - 1,
+        );
+        try appendValue(f64, end_value, compressed_values);
+    } else {
+        try appendValue(f64, current_segment.end_point.value, compressed_values);
+    }
+
+    try appendValue(usize, current_timestamp, compressed_values);
+}
+
+pub fn decompressSwingFilter(
+    compressed_values: []const u8,
+    decompressed_values: *ArrayList(f64),
+) Error!void {
+    // The compressed representation is composed of two values after getting the first since all
+    // segments are connected. Therefore, the condition checks that after the first value, the rest
+    // of the values are in pairs (end_value, end_time) and that they are all of type 64-bit float.
+    if ((compressed_values.len - 8) % 16 != 0) return Error.IncorrectInput;
+
+    const compressed_lines_and_index = mem.bytesAsSlice(f64, compressed_values);
+
+    var linear_approximation: LinearFunction = .{ .slope = undefined, .intercept = undefined };
+
+    var index: usize = 0;
+
+    // Extract the start point from the compressed representation.
+    var start_point: DiscretePoint = .{ .time = 0, .value = compressed_lines_and_index[0] };
+    try decompressed_values.append(start_point.value);
+    while (index < compressed_lines_and_index.len - 1) : (index += 2) {
+        // index + 1 is the end value and index + 2 is the end time.
+        const current_segment: Segment = .{
+            .start_point = start_point,
+            .end_point = .{
+                .time = @as(usize, @bitCast(compressed_lines_and_index[index + 2])) - 1,
+                .value = compressed_lines_and_index[index + 1],
+            },
+        };
+
+        if (current_segment.start_point.time < current_segment.end_point.time) {
+            // Create the linear approximation for the current segment.
+            updateSwingLinearFunction(current_segment, &linear_approximation, 0.0);
+            var current_timestamp: usize = current_segment.start_point.time + 1;
+            // Interpolate the values between the start and end points of the current segment.
+            while (current_timestamp < current_segment.end_point.time) : (current_timestamp += 1) {
+                const y: f64 = evaluateLinearFunctionAtTime(
+                    linear_approximation,
+                    usize,
+                    current_timestamp,
+                );
+                try decompressed_values.append(y);
+            }
+            try decompressed_values.append(current_segment.end_point.value);
+        }
+
+        // The start point of the next segment is the end point of the current segment.
+        start_point = current_segment.end_point;
+    }
+}
+
+/// Decompress `compressed_values` produced by "Slide Filter". This implementation is reused to
+/// decompress the "Swing Filter Disconnected" algorithm since the `compressed_values` are
+/// expected to have the same structure. The algorithm write the result to `decompressed_values`.
+/// If an error occurs it is returned.
+pub fn decompressSlideFilter(
     compressed_values: []const u8,
     decompressed_values: *ArrayList(f64),
 ) Error!void {
@@ -601,8 +827,42 @@ test "swing filter zero error bound and even size compress and decompress" {
 
     const uncompressed_values = list_values.items;
 
-    try compressSwing(uncompressed_values[0..], &compressed_values, error_bound);
-    try decompress(compressed_values.items, &decompressed_values);
+    try compressSwingFilter(uncompressed_values[0..], &compressed_values, error_bound);
+    try decompressSwingFilter(compressed_values.items, &decompressed_values);
+
+    try testing.expect(tersets.isWithinErrorBound(
+        uncompressed_values,
+        decompressed_values.items,
+        error_bound,
+    ));
+}
+
+test "swing filter disconnected zero error bound and even size compress and decompress" {
+    const allocator = testing.allocator;
+    const linear_function = LinearFunction{ .slope = 1, .intercept = 0.0 };
+
+    var list_values = ArrayList(f64).init(allocator);
+    defer list_values.deinit();
+    var compressed_values = ArrayList(u8).init(allocator);
+    defer compressed_values.deinit();
+    var decompressed_values = ArrayList(f64).init(allocator);
+    defer decompressed_values.deinit();
+    const error_bound: f32 = 0.0;
+
+    var rnd = std.Random.DefaultPrng.init(0);
+
+    var i: usize = 0;
+    while (i < 100) : (i += 1) {
+        const noise = rnd.random().float(f64) * 0.1 - 0.05;
+        try list_values.append(evaluateLinearFunctionAtTime(linear_function, usize, i) + noise);
+    }
+
+    const uncompressed_values = list_values.items;
+
+    try compressSwingFilterDisconnected(uncompressed_values[0..], &compressed_values, error_bound);
+    // Uses the same decompress function as the "Slide Filter" since the compressed values are
+    // expected to have the same structure.
+    try decompressSlideFilter(compressed_values.items, &decompressed_values);
 
     try testing.expect(tersets.isWithinErrorBound(
         uncompressed_values,
@@ -634,8 +894,8 @@ test "swing filter zero error bound and odd size compress and decompress" {
 
     const uncompressed_values = list_values.items;
 
-    try compressSwing(uncompressed_values[0..], &compressed_values, error_bound);
-    try decompress(compressed_values.items, &decompressed_values);
+    try compressSwingFilter(uncompressed_values[0..], &compressed_values, error_bound);
+    try decompressSwingFilter(compressed_values.items, &decompressed_values);
 
     try testing.expect(tersets.isWithinErrorBound(
         uncompressed_values,
@@ -689,8 +949,63 @@ test "swing filter four random lines and random error bound compress and decompr
 
     const uncompressed_values = list_values.items;
 
-    try compressSwing(uncompressed_values[0..], &compressed_values, error_bound);
-    try decompress(compressed_values.items, &decompressed_values);
+    try compressSwingFilter(uncompressed_values[0..], &compressed_values, error_bound);
+    try decompressSwingFilter(compressed_values.items, &decompressed_values);
+
+    try testing.expect(tersets.isWithinErrorBound(
+        uncompressed_values,
+        decompressed_values.items,
+        error_bound,
+    ));
+}
+
+test "swing filter disconnected four random lines and random error bound compress and decompress" {
+    const allocator = testing.allocator;
+    var rnd = std.Random.DefaultPrng.init(@as(u64, @bitCast(std.time.milliTimestamp())));
+
+    const linear_functions = [_]LinearFunction{
+        LinearFunction{
+            .slope = 2 * (rnd.random().float(f64) - 0.5),
+            .intercept = 2 * (rnd.random().float(f64) - 0.5),
+        },
+        LinearFunction{
+            .slope = 2 * (rnd.random().float(f64) - 0.5),
+            .intercept = 2 * (rnd.random().float(f64) - 0.5),
+        },
+        LinearFunction{
+            .slope = 2 * (rnd.random().float(f64) - 0.5),
+            .intercept = 2 * (rnd.random().float(f64) - 0.5),
+        },
+        LinearFunction{
+            .slope = 2 * (rnd.random().float(f64) - 0.5),
+            .intercept = 2 * (rnd.random().float(f64) - 0.5),
+        },
+    };
+
+    var list_values = ArrayList(f64).init(allocator);
+    defer list_values.deinit();
+    var compressed_values = ArrayList(u8).init(allocator);
+    defer compressed_values.deinit();
+    var decompressed_values = ArrayList(f64).init(allocator);
+    defer decompressed_values.deinit();
+    const error_bound: f32 = rnd.random().float(f32) * 0.1;
+
+    var i: usize = 0;
+    var lineIndex: usize = 0;
+    while (i < 1000) : (i += 1) {
+        lineIndex = i / 250;
+        const noise = rnd.random().float(f64) * 0.1 - 0.05;
+        try list_values.append(evaluateLinearFunctionAtTime(
+            linear_functions[lineIndex],
+            usize,
+            i,
+        ) + noise);
+    }
+
+    const uncompressed_values = list_values.items;
+
+    try compressSwingFilterDisconnected(uncompressed_values[0..], &compressed_values, error_bound);
+    try decompressSlideFilter(compressed_values.items, &decompressed_values);
 
     try testing.expect(tersets.isWithinErrorBound(
         uncompressed_values,
@@ -721,13 +1036,13 @@ test "slide filter zero error bound and even size compress and decompress" {
 
     const uncompressed_values = list_values.items;
 
-    try compressSlide(
+    try compressSlideFilter(
         uncompressed_values[0..],
         &compressed_values,
         allocator,
         error_bound,
     );
-    try decompress(compressed_values.items, &decompressed_values);
+    try decompressSlideFilter(compressed_values.items, &decompressed_values);
 
     try testing.expect(tersets.isWithinErrorBound(
         uncompressed_values,
@@ -759,13 +1074,13 @@ test "slide filter zero error bound and odd size compress and decompress" {
 
     const uncompressed_values = list_values.items;
 
-    try compressSlide(
+    try compressSlideFilter(
         uncompressed_values[0..],
         &compressed_values,
         allocator,
         error_bound,
     );
-    try decompress(compressed_values.items, &decompressed_values);
+    try decompressSlideFilter(compressed_values.items, &decompressed_values);
 
     try testing.expect(tersets.isWithinErrorBound(
         uncompressed_values,
@@ -819,13 +1134,13 @@ test "slide filter four random lines and random error bound compress and decompr
 
     const uncompressed_values = list_values.items;
 
-    try compressSlide(
+    try compressSlideFilter(
         uncompressed_values[0..],
         &compressed_values,
         allocator,
         error_bound,
     );
-    try decompress(compressed_values.items, &decompressed_values);
+    try decompressSlideFilter(compressed_values.items, &decompressed_values);
 
     try testing.expect(tersets.isWithinErrorBound(
         uncompressed_values,

--- a/src/functional/swing_slide_filter.zig
+++ b/src/functional/swing_slide_filter.zig
@@ -39,7 +39,10 @@ const testing = std.testing;
 const ArrayList = std.ArrayList;
 
 const tersets = @import("../tersets.zig");
+const Method = tersets.Method;
 const Error = tersets.Error;
+
+const tester = @import("../tester.zig");
 
 const shared = @import("../utilities/shared_structs.zig");
 const DiscretePoint = shared.DiscretePoint;
@@ -64,8 +67,8 @@ pub fn compressSwingFilter(
     else
         error_bound;
 
-    // Initialize the linear function used across the method. Their values will be defined as part
-    // of the method logic, thus now are undefined.
+    // Create the upper lower and upper bounds used throughout the function. They are uninitialized
+    // as they will be modified throughout the function.
     var upper_bound: LinearFunction = .{ .slope = undefined, .intercept = undefined };
     var lower_bound: LinearFunction = .{ .slope = undefined, .intercept = undefined };
     var new_upper_bound: LinearFunction = .{ .slope = undefined, .intercept = undefined };
@@ -83,6 +86,8 @@ pub fn compressSwingFilter(
     updateSwingLinearFunction(current_segment, &upper_bound, adjusted_error_bound);
     updateSwingLinearFunction(current_segment, &lower_bound, -adjusted_error_bound);
 
+    // Add the first point to the compressed values. From this point on, the algorithm will find all
+    // connected segments and add them to the compressed values.
     try appendValue(f64, current_segment.start_point.value, compressed_values);
 
     // The first two points are already part of `current_segment`, the next point is at index two.
@@ -95,7 +100,7 @@ pub fn compressSwingFilter(
         if ((upper_limit < (uncompressed_values[current_timestamp] - adjusted_error_bound)) or
             (lower_limit > (uncompressed_values[current_timestamp] + adjusted_error_bound)))
         {
-            // Recording mechanism (the current points is outside the limits).
+            // Recording mechanism (the current point is outside the limits).
             const segment_size = current_timestamp - current_segment.start_point.time - 1;
             if (segment_size > 1) {
                 // Denominator of Eq. (6).
@@ -143,7 +148,6 @@ pub fn compressSwingFilter(
                 updateSwingLinearFunction(current_segment, &upper_bound, adjusted_error_bound);
                 updateSwingLinearFunction(current_segment, &lower_bound, -adjusted_error_bound);
 
-                // current_timestamp += 1;
                 slope_derivate = computeSlopeDerivate(current_segment);
             } else {
                 // Only one point left. The `end_point` is at the `current_timestamp`.
@@ -185,9 +189,11 @@ pub fn compressSwingFilter(
         }
     }
 
+    // If the last segment is not empty, it means that the recording mechanism was not triggered.
+    // Thus, the current semgent has the last line segment which needs to be recorded.
+    // Given the way the for loop is structured, the last segment will always have at least one point.
     const segment_size = current_timestamp - current_segment.start_point.time - 1;
 
-    // try appendValue(f64, current_segment.start_point.value, compressed_values);
     if (segment_size > 1) {
         // Denominator of Eq. (6).
         const sum_square: f80 = @floatFromInt(
@@ -446,14 +452,14 @@ pub fn compressSwingFilterDisconnected(
     else
         error_bound;
 
-    // Initialize the linear function used across the method. Their values will be defined as part
-    // of the method logic, thus now are undefined.
+    // Create the upper lower and upper bounds used throughout the function. They are uninitialized
+    // as they will be modified throughout the function.
     var upper_bound: LinearFunction = .{ .slope = undefined, .intercept = undefined };
     var lower_bound: LinearFunction = .{ .slope = undefined, .intercept = undefined };
     var new_upper_bound: LinearFunction = .{ .slope = undefined, .intercept = undefined };
     var new_lower_bound: LinearFunction = .{ .slope = undefined, .intercept = undefined };
 
-    // Initialize the current segment with first two points.
+    // Initialize the current segment with the first two points.
     var current_segment: Segment = .{
         .start_point = .{ .time = 0, .value = uncompressed_values[0] },
         .end_point = .{ .time = 1, .value = uncompressed_values[1] },
@@ -468,14 +474,14 @@ pub fn compressSwingFilterDisconnected(
     // The first two points are already part of `current_segment`, the next point is at index two.
     var current_timestamp: usize = 2;
     while (current_timestamp < uncompressed_values.len) : (current_timestamp += 1) {
-        // Evaluate the upper and lower bound linear functions at the current timestamp.
+        // Calculate the upper and lower bound linear functions at the current timestamp.
         const upper_limit = evaluateLinearFunctionAtTime(upper_bound, usize, current_timestamp);
         const lower_limit = evaluateLinearFunctionAtTime(lower_bound, usize, current_timestamp);
 
         if ((upper_limit < (uncompressed_values[current_timestamp] - adjusted_error_bound)) or
             (lower_limit > (uncompressed_values[current_timestamp] + adjusted_error_bound)))
         {
-            // Recording mechanism (the current points is outside the limits).
+            // Recording mechanism (the current point is outside the limits).
             try appendValue(f64, current_segment.start_point.value, compressed_values);
             const segment_size = current_timestamp - current_segment.start_point.time - 1;
             if (segment_size > 1) {
@@ -514,7 +520,8 @@ pub fn compressSwingFilterDisconnected(
             current_segment.start_point.time = current_timestamp;
             current_segment.start_point.value = uncompressed_values[current_timestamp];
 
-            // Edge case as only one point is left.
+            // Check if there is only one point left. If so, update only the `end_point`.
+            // Otherwise, update the `end_point`, the upper and lower bounds and the `current_timestamp`.
             if (current_timestamp + 1 < uncompressed_values.len) {
                 current_segment.end_point.time = current_timestamp + 1;
                 current_segment.end_point.value = uncompressed_values[current_timestamp + 1];
@@ -535,6 +542,7 @@ pub fn compressSwingFilterDisconnected(
             current_segment.end_point.value = uncompressed_values[current_timestamp];
 
             // Update the potentially new upper and lower bounds with the new current point.
+            // If the new lines create tighter bounds, update the upper and lower bounds.
             updateSwingLinearFunction(current_segment, &new_upper_bound, adjusted_error_bound);
             updateSwingLinearFunction(current_segment, &new_lower_bound, -adjusted_error_bound);
 
@@ -564,9 +572,13 @@ pub fn compressSwingFilterDisconnected(
         }
     }
 
+    // If the last segment is not empty, it means that the recording mechanism was not triggered.
+    // Thus, the current semgent has the last line segment which needs to be recorded.
+    // Given the way the for loop is structured, the last segment will always have at least one point.
     const segment_size = current_timestamp - current_segment.start_point.time - 1;
 
     try appendValue(f64, current_segment.start_point.value, compressed_values);
+    // Check if the last segment has more than one point. If so, the recording mechanism is triggered.
     if (segment_size > 1) {
         // Denominator of Eq. (6).
         const sum_square: f80 = @floatFromInt(
@@ -595,17 +607,20 @@ pub fn compressSwingFilterDisconnected(
         );
         try appendValue(f64, end_value, compressed_values);
     } else {
+        // Only point left. The `end_point` is at the `current_timestamp`.
         try appendValue(f64, current_segment.end_point.value, compressed_values);
     }
-
+    // The `current_timestamp` indicate the final timestamp.
     try appendValue(usize, current_timestamp, compressed_values);
 }
 
+/// Decompress `compressed_values` produced by "Swing Filter". The algorithm write the result to
+/// `decompressed_values`. If an error occurs it is returned.
 pub fn decompressSwingFilter(
     compressed_values: []const u8,
     decompressed_values: *ArrayList(f64),
 ) Error!void {
-    // The compressed representation is composed of two values after getting the first since all
+    // The compressed representation is composed of two values after extracting the first since all
     // segments are connected. Therefore, the condition checks that after the first value, the rest
     // of the values are in pairs (end_value, end_time) and that they are all of type 64-bit float.
     if ((compressed_values.len - 8) % 16 != 0) return Error.IncorrectInput;
@@ -619,6 +634,8 @@ pub fn decompressSwingFilter(
     // Extract the start point from the compressed representation.
     var start_point: DiscretePoint = .{ .time = 0, .value = compressed_lines_and_index[0] };
     try decompressed_values.append(start_point.value);
+
+    // Iterate over the compressed representation to reconstruct the time series
     while (index < compressed_lines_and_index.len - 1) : (index += 2) {
         // index + 1 is the end value and index + 2 is the end time.
         const current_segment: Segment = .{
@@ -629,7 +646,9 @@ pub fn decompressSwingFilter(
             },
         };
 
-        if (current_segment.start_point.time < current_segment.end_point.time) {
+        // Check if the start and end points of the current segment are different. If they are the same,
+        // it means that the segment is a single point, and we can directly append the value.
+        if (current_segment.start_point.time != current_segment.end_point.time) {
             // Create the linear approximation for the current segment.
             updateSwingLinearFunction(current_segment, &linear_approximation, 0.0);
             var current_timestamp: usize = current_segment.start_point.time + 1;
@@ -643,6 +662,9 @@ pub fn decompressSwingFilter(
                 try decompressed_values.append(y);
             }
             try decompressed_values.append(current_segment.end_point.value);
+        } else {
+            // If the start and end points are the same, append the start point value directly.
+            try decompressed_values.append(current_segment.start_point.value);
         }
 
         // The start point of the next segment is the end point of the current segment.
@@ -668,6 +690,7 @@ pub fn decompressSlideFilter(
 
     var first_timestamp: usize = 0;
     var index: usize = 0;
+
     while (index < compressed_lines_and_index.len) : (index += 3) {
         const current_segment: Segment = .{
             .start_point = .{ .time = first_timestamp, .value = compressed_lines_and_index[index] },
@@ -677,10 +700,14 @@ pub fn decompressSlideFilter(
             },
         };
 
-        if (current_segment.start_point.time < current_segment.end_point.time) {
+        // Check if the start and end points of the current segment are different. If they are the same,
+        // it means that the segment is a single point, and we can directly append the value.
+        if (current_segment.start_point.time != current_segment.end_point.time) {
             updateSwingLinearFunction(current_segment, &linear_approximation, 0.0);
             try decompressed_values.append(current_segment.start_point.value);
             var current_timestamp: usize = current_segment.start_point.time + 1;
+
+            // Interpolate the values between the start and end points of the current segment.
             while (current_timestamp < current_segment.end_point.time) : (current_timestamp += 1) {
                 const y: f64 = evaluateLinearFunctionAtTime(
                     linear_approximation,
@@ -692,6 +719,7 @@ pub fn decompressSlideFilter(
             try decompressed_values.append(current_segment.end_point.value);
             first_timestamp = current_timestamp + 1;
         } else {
+            // If the start and end points are the same, append the start point value directly.
             try decompressed_values.append(current_segment.start_point.value);
             first_timestamp += 1;
         }
@@ -805,33 +833,58 @@ fn usizeToF80(value: usize) f80 {
     return @as(f80, @floatFromInt(value));
 }
 
+test "swing filter can always compress and decompress" {
+    const allocator = testing.allocator;
+    try tester.testGenerateCompressAndDecompress(
+        tester.generateRandomValues,
+        allocator,
+        Method.SwingFilter,
+        0,
+        tersets.isWithinErrorBound,
+    );
+}
+
+test "swing filter disconnected can always compress and decompress" {
+    const allocator = testing.allocator;
+    try tester.testGenerateCompressAndDecompress(
+        tester.generateRandomValues,
+        allocator,
+        Method.SwingFilterDisconnected,
+        0,
+        tersets.isWithinErrorBound,
+    );
+}
+
+test "slide filter disconnected can always compress and decompress" {
+    const allocator = testing.allocator;
+    try tester.testGenerateCompressAndDecompress(
+        tester.generateRandomValues,
+        allocator,
+        Method.SlideFilter,
+        0,
+        tersets.isWithinErrorBound,
+    );
+}
+
 test "swing filter zero error bound and even size compress and decompress" {
     const allocator = testing.allocator;
-    const linear_function = LinearFunction{ .slope = 1, .intercept = 0.0 };
 
-    var list_values = ArrayList(f64).init(allocator);
-    defer list_values.deinit();
+    var uncompressed_values = ArrayList(f64).init(allocator);
+    defer uncompressed_values.deinit();
     var compressed_values = ArrayList(u8).init(allocator);
     defer compressed_values.deinit();
     var decompressed_values = ArrayList(f64).init(allocator);
     defer decompressed_values.deinit();
+
     const error_bound: f32 = 0.0;
 
-    var rnd = std.Random.DefaultPrng.init(0);
+    try tester.generateBoundedRandomValues(&uncompressed_values, 0.0, 1.0, undefined);
 
-    var i: usize = 0;
-    while (i < 100) : (i += 1) {
-        const noise = rnd.random().float(f64) * 0.1 - 0.05;
-        try list_values.append(evaluateLinearFunctionAtTime(linear_function, usize, i) + noise);
-    }
-
-    const uncompressed_values = list_values.items;
-
-    try compressSwingFilter(uncompressed_values[0..], &compressed_values, error_bound);
+    try compressSwingFilter(uncompressed_values.items, &compressed_values, error_bound);
     try decompressSwingFilter(compressed_values.items, &decompressed_values);
 
     try testing.expect(tersets.isWithinErrorBound(
-        uncompressed_values,
+        uncompressed_values.items,
         decompressed_values.items,
         error_bound,
     ));
@@ -839,33 +892,25 @@ test "swing filter zero error bound and even size compress and decompress" {
 
 test "swing filter disconnected zero error bound and even size compress and decompress" {
     const allocator = testing.allocator;
-    const linear_function = LinearFunction{ .slope = 1, .intercept = 0.0 };
 
-    var list_values = ArrayList(f64).init(allocator);
-    defer list_values.deinit();
+    var uncompressed_values = ArrayList(f64).init(allocator);
+    defer uncompressed_values.deinit();
     var compressed_values = ArrayList(u8).init(allocator);
     defer compressed_values.deinit();
     var decompressed_values = ArrayList(f64).init(allocator);
     defer decompressed_values.deinit();
+
     const error_bound: f32 = 0.0;
 
-    var rnd = std.Random.DefaultPrng.init(0);
+    try tester.generateBoundedRandomValues(&uncompressed_values, 0.0, 1.0, undefined);
 
-    var i: usize = 0;
-    while (i < 100) : (i += 1) {
-        const noise = rnd.random().float(f64) * 0.1 - 0.05;
-        try list_values.append(evaluateLinearFunctionAtTime(linear_function, usize, i) + noise);
-    }
-
-    const uncompressed_values = list_values.items;
-
-    try compressSwingFilterDisconnected(uncompressed_values[0..], &compressed_values, error_bound);
+    try compressSwingFilterDisconnected(uncompressed_values.items, &compressed_values, error_bound);
     // Uses the same decompress function as the "Slide Filter" since the compressed values are
     // expected to have the same structure.
     try decompressSlideFilter(compressed_values.items, &decompressed_values);
 
     try testing.expect(tersets.isWithinErrorBound(
-        uncompressed_values,
+        uncompressed_values.items,
         decompressed_values.items,
         error_bound,
     ));
@@ -874,141 +919,79 @@ test "swing filter disconnected zero error bound and even size compress and deco
 test "swing filter zero error bound and odd size compress and decompress" {
     const allocator = testing.allocator;
 
-    const linear_function = LinearFunction{ .slope = 1, .intercept = 0.0 };
-
-    var list_values = ArrayList(f64).init(allocator);
-    defer list_values.deinit();
+    var uncompressed_values = ArrayList(f64).init(allocator);
+    defer uncompressed_values.deinit();
     var compressed_values = ArrayList(u8).init(allocator);
     defer compressed_values.deinit();
     var decompressed_values = ArrayList(f64).init(allocator);
     defer decompressed_values.deinit();
+
     const error_bound: f32 = 0.0;
 
-    var rnd = std.Random.DefaultPrng.init(0);
+    try tester.generateBoundedRandomValues(&uncompressed_values, 0.0, 1.0, undefined);
 
-    var i: usize = 0;
-    while (i < 101) : (i += 1) {
-        const noise = rnd.random().float(f64) * 0.1 - 0.05;
-        try list_values.append(evaluateLinearFunctionAtTime(linear_function, usize, i) + noise);
-    }
+    //  Extra element to make the size odd.
+    try uncompressed_values.append(tester.getRandomNumberGenerator().float(f64));
 
-    const uncompressed_values = list_values.items;
-
-    try compressSwingFilter(uncompressed_values[0..], &compressed_values, error_bound);
+    try compressSwingFilter(uncompressed_values.items, &compressed_values, error_bound);
     try decompressSwingFilter(compressed_values.items, &decompressed_values);
 
     try testing.expect(tersets.isWithinErrorBound(
-        uncompressed_values,
+        uncompressed_values.items,
         decompressed_values.items,
         error_bound,
     ));
 }
 
-test "swing filter four random lines and random error bound compress and decompress" {
+test "swing filter random lines and random error bound compress and decompress" {
     const allocator = testing.allocator;
-    var rnd = std.Random.DefaultPrng.init(@as(u64, @bitCast(std.time.milliTimestamp())));
 
-    const linear_functions = [_]LinearFunction{
-        LinearFunction{
-            .slope = 2 * (rnd.random().float(f64) - 0.5),
-            .intercept = 2 * (rnd.random().float(f64) - 0.5),
-        },
-        LinearFunction{
-            .slope = 2 * (rnd.random().float(f64) - 0.5),
-            .intercept = 2 * (rnd.random().float(f64) - 0.5),
-        },
-        LinearFunction{
-            .slope = 2 * (rnd.random().float(f64) - 0.5),
-            .intercept = 2 * (rnd.random().float(f64) - 0.5),
-        },
-        LinearFunction{
-            .slope = 2 * (rnd.random().float(f64) - 0.5),
-            .intercept = 2 * (rnd.random().float(f64) - 0.5),
-        },
-    };
-
-    var list_values = ArrayList(f64).init(allocator);
-    defer list_values.deinit();
+    var uncompressed_values = ArrayList(f64).init(allocator);
+    defer uncompressed_values.deinit();
     var compressed_values = ArrayList(u8).init(allocator);
     defer compressed_values.deinit();
     var decompressed_values = ArrayList(f64).init(allocator);
     defer decompressed_values.deinit();
-    const error_bound: f32 = rnd.random().float(f32) * 0.1;
 
-    var i: usize = 0;
-    var lineIndex: usize = 0;
-    while (i < 1000) : (i += 1) {
-        lineIndex = i / 250;
-        const noise = rnd.random().float(f64) * 0.1 - 0.05;
-        try list_values.append(evaluateLinearFunctionAtTime(
-            linear_functions[lineIndex],
-            usize,
-            i,
-        ) + noise);
+    const error_bound: f32 = tester.getRandomNumberGenerator().float(f32) * 10;
+
+    for (0..tester.getRandomNumberGenerator().intRangeAtMost(usize, 4, 20)) |_| {
+        // Generate a random linear function and add it to the uncompressed values.
+        try tester.generateRandomLinearFunction(&uncompressed_values, undefined);
     }
 
-    const uncompressed_values = list_values.items;
-
-    try compressSwingFilter(uncompressed_values[0..], &compressed_values, error_bound);
+    try compressSwingFilter(uncompressed_values.items, &compressed_values, error_bound);
     try decompressSwingFilter(compressed_values.items, &decompressed_values);
 
     try testing.expect(tersets.isWithinErrorBound(
-        uncompressed_values,
+        uncompressed_values.items,
         decompressed_values.items,
         error_bound,
     ));
 }
 
-test "swing filter disconnected four random lines and random error bound compress and decompress" {
+test "swing filter disconnected random lines and random error bound compress and decompress" {
     const allocator = testing.allocator;
-    var rnd = std.Random.DefaultPrng.init(@as(u64, @bitCast(std.time.milliTimestamp())));
 
-    const linear_functions = [_]LinearFunction{
-        LinearFunction{
-            .slope = 2 * (rnd.random().float(f64) - 0.5),
-            .intercept = 2 * (rnd.random().float(f64) - 0.5),
-        },
-        LinearFunction{
-            .slope = 2 * (rnd.random().float(f64) - 0.5),
-            .intercept = 2 * (rnd.random().float(f64) - 0.5),
-        },
-        LinearFunction{
-            .slope = 2 * (rnd.random().float(f64) - 0.5),
-            .intercept = 2 * (rnd.random().float(f64) - 0.5),
-        },
-        LinearFunction{
-            .slope = 2 * (rnd.random().float(f64) - 0.5),
-            .intercept = 2 * (rnd.random().float(f64) - 0.5),
-        },
-    };
-
-    var list_values = ArrayList(f64).init(allocator);
-    defer list_values.deinit();
+    var uncompressed_values = ArrayList(f64).init(allocator);
+    defer uncompressed_values.deinit();
     var compressed_values = ArrayList(u8).init(allocator);
     defer compressed_values.deinit();
     var decompressed_values = ArrayList(f64).init(allocator);
     defer decompressed_values.deinit();
-    const error_bound: f32 = rnd.random().float(f32) * 0.1;
 
-    var i: usize = 0;
-    var lineIndex: usize = 0;
-    while (i < 1000) : (i += 1) {
-        lineIndex = i / 250;
-        const noise = rnd.random().float(f64) * 0.1 - 0.05;
-        try list_values.append(evaluateLinearFunctionAtTime(
-            linear_functions[lineIndex],
-            usize,
-            i,
-        ) + noise);
+    const error_bound: f32 = tester.getRandomNumberGenerator().float(f32) * 10;
+
+    for (0..tester.getRandomNumberGenerator().intRangeAtMost(usize, 4, 20)) |_| {
+        // Generate a random linear function and add it to the uncompressed values.
+        try tester.generateRandomLinearFunction(&uncompressed_values, undefined);
     }
 
-    const uncompressed_values = list_values.items;
-
-    try compressSwingFilterDisconnected(uncompressed_values[0..], &compressed_values, error_bound);
+    try compressSwingFilterDisconnected(uncompressed_values.items, &compressed_values, error_bound);
     try decompressSlideFilter(compressed_values.items, &decompressed_values);
 
     try testing.expect(tersets.isWithinErrorBound(
-        uncompressed_values,
+        uncompressed_values.items,
         decompressed_values.items,
         error_bound,
     ));
@@ -1016,28 +999,22 @@ test "swing filter disconnected four random lines and random error bound compres
 
 test "slide filter zero error bound and even size compress and decompress" {
     const allocator = testing.allocator;
-    const linear_function = LinearFunction{ .slope = 1, .intercept = 0.0 };
 
-    var list_values = ArrayList(f64).init(allocator);
-    defer list_values.deinit();
+    var uncompressed_values = ArrayList(f64).init(allocator);
+    defer uncompressed_values.deinit();
     var compressed_values = ArrayList(u8).init(allocator);
     defer compressed_values.deinit();
     var decompressed_values = ArrayList(f64).init(allocator);
     defer decompressed_values.deinit();
+
+    // Zero error bound is curently failing due to numerical instabilities at very high precision levels.
+    // The error occurs
     const error_bound: f32 = 0.0;
 
-    var rnd = std.Random.DefaultPrng.init(@as(u64, @bitCast(std.time.milliTimestamp())));
-
-    var i: usize = 0;
-    while (i < 100) : (i += 1) {
-        const noise = rnd.random().float(f64) * 0.1 - 0.05;
-        try list_values.append(evaluateLinearFunctionAtTime(linear_function, usize, i) + noise);
-    }
-
-    const uncompressed_values = list_values.items;
+    try tester.generateBoundedRandomValues(&uncompressed_values, 0.0, 1.0, undefined);
 
     try compressSlideFilter(
-        uncompressed_values[0..],
+        uncompressed_values.items,
         &compressed_values,
         allocator,
         error_bound,
@@ -1045,7 +1022,7 @@ test "slide filter zero error bound and even size compress and decompress" {
     try decompressSlideFilter(compressed_values.items, &decompressed_values);
 
     try testing.expect(tersets.isWithinErrorBound(
-        uncompressed_values,
+        uncompressed_values.items,
         decompressed_values.items,
         error_bound,
     ));
@@ -1054,28 +1031,21 @@ test "slide filter zero error bound and even size compress and decompress" {
 test "slide filter zero error bound and odd size compress and decompress" {
     const allocator = testing.allocator;
 
-    const linear_function = LinearFunction{ .slope = 1, .intercept = 0.0 };
-
-    var list_values = ArrayList(f64).init(allocator);
-    defer list_values.deinit();
+    var uncompressed_values = ArrayList(f64).init(allocator);
+    defer uncompressed_values.deinit();
     var compressed_values = ArrayList(u8).init(allocator);
     defer compressed_values.deinit();
     var decompressed_values = ArrayList(f64).init(allocator);
     defer decompressed_values.deinit();
+
     const error_bound: f32 = 0.0;
 
-    var rnd = std.Random.DefaultPrng.init(0);
-
-    var i: usize = 0;
-    while (i < 101) : (i += 1) {
-        const noise = rnd.random().float(f64) * 0.1 - 0.05;
-        try list_values.append(evaluateLinearFunctionAtTime(linear_function, usize, i) + noise);
-    }
-
-    const uncompressed_values = list_values.items;
+    try tester.generateBoundedRandomValues(&uncompressed_values, 0.0, 1.0, undefined);
+    //  Extra element to make the size odd.
+    try uncompressed_values.append(tester.getRandomNumberGenerator().float(f64));
 
     try compressSlideFilter(
-        uncompressed_values[0..],
+        uncompressed_values.items,
         &compressed_values,
         allocator,
         error_bound,
@@ -1083,59 +1053,31 @@ test "slide filter zero error bound and odd size compress and decompress" {
     try decompressSlideFilter(compressed_values.items, &decompressed_values);
 
     try testing.expect(tersets.isWithinErrorBound(
-        uncompressed_values,
+        uncompressed_values.items,
         decompressed_values.items,
         error_bound,
     ));
 }
 
-test "slide filter four random lines and random error bound compress and decompress" {
+test "slide filter random lines and random error bound compress and decompress" {
     const allocator = testing.allocator;
-    var rnd = std.Random.DefaultPrng.init(@as(u64, @bitCast(std.time.milliTimestamp())));
 
-    const linear_functions = [_]LinearFunction{
-        LinearFunction{
-            .slope = 2 * (rnd.random().float(f64) - 0.5),
-            .intercept = 2 * (rnd.random().float(f64) - 0.5),
-        },
-        LinearFunction{
-            .slope = 2 * (rnd.random().float(f64) - 0.5),
-            .intercept = 2 * (rnd.random().float(f64) - 0.5),
-        },
-        LinearFunction{
-            .slope = 2 * (rnd.random().float(f64) - 0.5),
-            .intercept = 2 * (rnd.random().float(f64) - 0.5),
-        },
-        LinearFunction{
-            .slope = 2 * (rnd.random().float(f64) - 0.5),
-            .intercept = 2 * (rnd.random().float(f64) - 0.5),
-        },
-    };
-
-    var list_values = ArrayList(f64).init(allocator);
-    defer list_values.deinit();
+    var uncompressed_values = ArrayList(f64).init(allocator);
+    defer uncompressed_values.deinit();
     var compressed_values = ArrayList(u8).init(allocator);
     defer compressed_values.deinit();
     var decompressed_values = ArrayList(f64).init(allocator);
     defer decompressed_values.deinit();
-    const error_bound: f32 = rnd.random().float(f32);
 
-    var i: usize = 0;
-    var lineIndex: usize = 0;
-    while (i < 100) : (i += 1) {
-        lineIndex = i / 250;
-        const noise = rnd.random().float(f64) - 0.05;
-        try list_values.append(evaluateLinearFunctionAtTime(
-            linear_functions[lineIndex],
-            usize,
-            i,
-        ) + noise);
+    const error_bound: f32 = tester.getRandomNumberGenerator().float(f32) * 10;
+
+    for (0..tester.getRandomNumberGenerator().intRangeAtMost(usize, 4, 20)) |_| {
+        // Generate a random linear function and add it to the uncompressed values.
+        try tester.generateRandomLinearFunction(&uncompressed_values, undefined);
     }
 
-    const uncompressed_values = list_values.items;
-
     try compressSlideFilter(
-        uncompressed_values[0..],
+        uncompressed_values.items,
         &compressed_values,
         allocator,
         error_bound,
@@ -1143,7 +1085,7 @@ test "slide filter four random lines and random error bound compress and decompr
     try decompressSlideFilter(compressed_values.items, &decompressed_values);
 
     try testing.expect(tersets.isWithinErrorBound(
-        uncompressed_values,
+        uncompressed_values.items,
         decompressed_values.items,
         error_bound,
     ));

--- a/src/functional/swing_slide_filter.zig
+++ b/src/functional/swing_slide_filter.zig
@@ -931,7 +931,7 @@ test "swing filter zero error bound and odd size compress and decompress" {
     try tester.generateBoundedRandomValues(&uncompressed_values, 0.0, 1.0, undefined);
 
     //  Extra element to make the size odd.
-    try uncompressed_values.append(tester.getRandomNumberGenerator().float(f64));
+    try uncompressed_values.append(0.1);
 
     try compressSwingFilter(uncompressed_values.items, &compressed_values, error_bound);
     try decompressSwingFilter(compressed_values.items, &decompressed_values);
@@ -953,9 +953,10 @@ test "swing filter random lines and random error bound compress and decompress" 
     var decompressed_values = ArrayList(f64).init(allocator);
     defer decompressed_values.deinit();
 
-    const error_bound: f32 = tester.getRandomNumberGenerator().float(f32) * 10;
+    const error_bound: f32 = tester.generateBoundedRandomValue(f32, 1, 10, undefined);
 
-    for (0..tester.getRandomNumberGenerator().intRangeAtMost(usize, 4, 20)) |_| {
+    const max_lines: usize = @intFromFloat(@round(tester.generateBoundedRandomValue(f64, 4, 25, undefined)));
+    for (0..max_lines) |_| {
         // Generate a random linear function and add it to the uncompressed values.
         try tester.generateRandomLinearFunction(&uncompressed_values, undefined);
     }
@@ -980,9 +981,11 @@ test "swing filter disconnected random lines and random error bound compress and
     var decompressed_values = ArrayList(f64).init(allocator);
     defer decompressed_values.deinit();
 
-    const error_bound: f32 = tester.getRandomNumberGenerator().float(f32) * 10;
+    const error_bound: f32 = tester.generateBoundedRandomValue(f32, 1, 10, undefined);
 
-    for (0..tester.getRandomNumberGenerator().intRangeAtMost(usize, 4, 20)) |_| {
+    const max_lines: usize = @intFromFloat(@round(tester.generateBoundedRandomValue(f64, 4, 25, undefined)));
+
+    for (0..max_lines) |_| {
         // Generate a random linear function and add it to the uncompressed values.
         try tester.generateRandomLinearFunction(&uncompressed_values, undefined);
     }
@@ -1042,7 +1045,7 @@ test "slide filter zero error bound and odd size compress and decompress" {
 
     try tester.generateBoundedRandomValues(&uncompressed_values, 0.0, 1.0, undefined);
     //  Extra element to make the size odd.
-    try uncompressed_values.append(tester.getRandomNumberGenerator().float(f64));
+    try uncompressed_values.append(0.1);
 
     try compressSlideFilter(
         uncompressed_values.items,
@@ -1069,9 +1072,11 @@ test "slide filter random lines and random error bound compress and decompress" 
     var decompressed_values = ArrayList(f64).init(allocator);
     defer decompressed_values.deinit();
 
-    const error_bound: f32 = tester.getRandomNumberGenerator().float(f32) * 10;
+    const error_bound: f32 = tester.generateBoundedRandomValue(f32, 1, 10, undefined);
 
-    for (0..tester.getRandomNumberGenerator().intRangeAtMost(usize, 4, 20)) |_| {
+    const max_lines: usize = @intFromFloat(@round(tester.generateBoundedRandomValue(f64, 4, 25, undefined)));
+
+    for (0..max_lines) |_| {
         // Generate a random linear function and add it to the uncompressed values.
         try tester.generateRandomLinearFunction(&uncompressed_values, undefined);
     }

--- a/src/tersets.zig
+++ b/src/tersets.zig
@@ -39,6 +39,7 @@ pub const Method = enum {
     PoorMansCompressionMidrange,
     PoorMansCompressionMean,
     SwingFilter,
+    SwingFilterDisconnected,
     SlideFilter,
     SimPiece,
     PiecewiseConstantHistogram,
@@ -76,14 +77,21 @@ pub fn compress(
             );
         },
         .SwingFilter => {
-            try swing_slide_filter.compressSwing(
+            try swing_slide_filter.compressSwingFilter(
+                uncompressed_values,
+                &compressed_values,
+                error_bound,
+            );
+        },
+        .SwingFilterDisconnected => {
+            try swing_slide_filter.compressSwingFilterDisconnected(
                 uncompressed_values,
                 &compressed_values,
                 error_bound,
             );
         },
         .SlideFilter => {
-            try swing_slide_filter.compressSlide(
+            try swing_slide_filter.compressSlideFilter(
                 uncompressed_values,
                 &compressed_values,
                 allocator,
@@ -140,8 +148,11 @@ pub fn decompress(
         .PoorMansCompressionMidrange, .PoorMansCompressionMean => {
             try poor_mans_compression.decompress(compressed_values_slice, &decompressed_values);
         },
-        .SwingFilter, .SlideFilter => {
-            try swing_slide_filter.decompress(compressed_values_slice, &decompressed_values);
+        .SwingFilter => {
+            try swing_slide_filter.decompressSwingFilter(compressed_values_slice, &decompressed_values);
+        },
+        .SwingFilterDisconnected, .SlideFilter => {
+            try swing_slide_filter.decompressSlideFilter(compressed_values_slice, &decompressed_values);
         },
         .SimPiece => {
             try sim_piece.decompress(compressed_values_slice, &decompressed_values, allocator);

--- a/src/tester.zig
+++ b/src/tester.zig
@@ -192,7 +192,9 @@ pub fn generateBoundedRandomValues(
     upper_bound: f64,
     random_opt: ?Random,
 ) !void {
-    var random = random_opt orelse getRandomNumberGenerator();
+    const seed: u64 = @bitCast(time.milliTimestamp());
+    var prng = std.Random.DefaultPrng.init(seed);
+    var random = random_opt orelse prng.random();
 
     for (0..number_of_values) |_| {
         // generate f64 values in the range [0, 1).
@@ -207,7 +209,9 @@ pub fn generateBoundedRandomValues(
 /// add to `uncompressed_values`.If `random_opt` is not passed, a random number generator is created.
 pub fn generateRandomLinearFunction(uncompressed_values: *ArrayList(f64), random_opt: ?Random) !void {
     // If `random_opt` is not passed, a random number generator is created using the current time as seed.
-    var random = random_opt orelse getRandomNumberGenerator();
+    const seed: u64 = @bitCast(time.milliTimestamp());
+    var prng = std.Random.DefaultPrng.init(seed);
+    var random = random_opt orelse prng.random();
 
     // Generate a random slope in the range [-10, 10]. Multiply by 1000 to increase changes of getting
     // a value different from zero.
@@ -227,15 +231,12 @@ pub fn generateRandomLinearFunction(uncompressed_values: *ArrayList(f64), random
 
 /// Return a random `f64` value between `lower_bound` and `upper_bound` for
 /// use in testing using `random`.
-pub fn generateBoundedRandomValue(lower_bound: f64, upper_bound: f64, random: Random) f64 {
-    const rand_value: f64 = random.float(f64);
-    const bounded_value = lower_bound + (upper_bound - lower_bound) * rand_value;
-    return bounded_value;
-}
-
-/// Returns an engine to generate random numbers using the current time as seed.
-pub fn getRandomNumberGenerator() Random {
+pub fn generateBoundedRandomValue(comptime T: type, lower_bound: T, upper_bound: T, random_opt: ?Random) T {
     const seed: u64 = @bitCast(time.milliTimestamp());
     var prng = std.Random.DefaultPrng.init(seed);
-    return prng.random();
+    var random = random_opt orelse prng.random();
+
+    const rand_value: T = random.float(T);
+    const bounded_value = lower_bound + (upper_bound - lower_bound) * rand_value;
+    return bounded_value;
 }

--- a/src/tester.zig
+++ b/src/tester.zig
@@ -190,8 +190,10 @@ pub fn generateBoundedRandomValues(
     uncompressed_values: *ArrayList(f64),
     lower_bound: f64,
     upper_bound: f64,
-    random: Random,
+    random_opt: ?Random,
 ) !void {
+    var random = random_opt orelse getRandomNumberGenerator();
+
     for (0..number_of_values) |_| {
         // generate f64 values in the range [0, 1).
         const rand_value: f64 = random.float(f64);
@@ -201,21 +203,23 @@ pub fn generateBoundedRandomValues(
 }
 
 /// Generate `number_of_values` of random `f64` values following a linear function of random slope
-/// and intercept for use in testing using `random`. Random noise is add to the elements and then
-/// add to `uncompressed_values`.
-pub fn generateRandomLinearFunction(uncompressed_values: *ArrayList(f64), random: Random) !void {
-    // Generate a f64 in the range [0, 1) and use it to generate a random `slope` between 0 and 10
-    // with two precision values. This slope enables enough variety while keeping the values within
-    // the acceptable range.
-    var rand_value: f64 = random.float(f64);
-    const slope: f64 = @round(rand_value * 1000) / 100;
+/// and intercept for use in testing using `random_opt`. Random noise is add to the elements and then
+/// add to `uncompressed_values`.If `random_opt` is not passed, a random number generator is created.
+pub fn generateRandomLinearFunction(uncompressed_values: *ArrayList(f64), random_opt: ?Random) !void {
+    // If `random_opt` is not passed, a random number generator is created using the current time as seed.
+    var random = random_opt orelse getRandomNumberGenerator();
 
-    // Repeat to generate a random intercept.
+    // Generate a random slope in the range [-10, 10]. Multiply by 1000 to increase changes of getting
+    // a value different from zero.
+    var rand_value: f64 = random.float(f64);
+    const slope: f64 = @round((rand_value - 0.5) * 1000) / 100;
+
+    // Repeat the process before to generate a random intercept in the range [-10, 10].
     rand_value = random.float(f64);
-    const intercept: f64 = @round(rand_value * 1000) / 10;
+    const intercept: f64 = @round((rand_value - 0.5) * 1000) / 100;
 
     for (0..number_of_values) |x| {
-        rand_value = random.float(f64);
+        rand_value = random.float(f64) - 0.5; // Random noise in the range [-0.5, 0.5).
         const linear_function_value = slope * @as(f64, @floatFromInt(x)) + intercept + rand_value;
         try uncompressed_values.append(linear_function_value);
     }
@@ -227,4 +231,11 @@ pub fn generateBoundedRandomValue(lower_bound: f64, upper_bound: f64, random: Ra
     const rand_value: f64 = random.float(f64);
     const bounded_value = lower_bound + (upper_bound - lower_bound) * rand_value;
     return bounded_value;
+}
+
+/// Returns an engine to generate random numbers using the current time as seed.
+pub fn getRandomNumberGenerator() Random {
+    const seed: u64 = @bitCast(time.milliTimestamp());
+    var prng = std.Random.DefaultPrng.init(seed);
+    return prng.random();
 }


### PR DESCRIPTION
This PR reimplements the Swing Filter algorithm to follow its original paper [1]. Specifically, the current implementation created disconnected segments, while in the proposed algorithm [1], the segments are connected by taking the previous endpoint as the first endpoint of the segment. This has advantages and disadvantages; therefore, we now include both implementations and let the user decide which one they want. The previous Swing Filter implementation is now called "Swing Filter Disconnected", while the originally proposed method is called "Swing Filter". Since [1] mentions the possibility of disconnecting the segments, and since both methods are interesting and produce different results, I believe their implementations belong in the same file.     

This PR also adds the necessary testing for this new implementation and fixes the Method enum in `tersets.zig` and the Python binding. 

[1] https://doi.org/10.14778/1687627.1687645