### PR TITLE
Fix random generation function

### DIFF
--- a/src/capi.zig
+++ b/src/capi.zig
@@ -107,6 +107,7 @@ fn errorToInt(err: Error) i32 {
         Error.OutOfMemory => return 5,
         Error.ItemNotFound => return 6,
         Error.EmptyConvexHull => return 7,
+        Error.InvalidInput => return 8,
     }
 }
 

--- a/src/capi.zig
+++ b/src/capi.zig
@@ -101,13 +101,11 @@ fn Array(comptime data_type: type) type {
 fn errorToInt(err: Error) i32 {
     switch (err) {
         Error.UnknownMethod => return 1,
-        Error.EmptyInput => return 2,
+        Error.UnsupportedInput => return 2,
         Error.UnsupportedErrorBound => return 3,
-        Error.IncorrectInput => return 4,
-        Error.OutOfMemory => return 5,
-        Error.ItemNotFound => return 6,
-        Error.EmptyConvexHull => return 7,
-        Error.InvalidInput => return 8,
+        Error.OutOfMemory => return 4,
+        Error.ItemNotFound => return 5,
+        Error.EmptyConvexHull => return 6,
     }
 }
 

--- a/src/functional/histogram_compression.zig
+++ b/src/functional/histogram_compression.zig
@@ -74,7 +74,7 @@ pub fn compressPWCH(
 
     for (uncompressed_values, 0..) |elem, index| {
         // Check if the current point is NaN or infinite. If so, return an error.
-        if (!math.isFinite(elem)) return Error.InvalidInput;
+        if (!math.isFinite(elem)) return Error.UnsupportedInput;
 
         try histogram.insert(index, elem);
     }
@@ -112,7 +112,7 @@ pub fn compressPWLH(
 
     for (uncompressed_values, 0..) |elem, index| {
         // Check if the current point is NaN or infinite. If so, return an error.
-        if (!math.isFinite(elem)) return Error.InvalidInput;
+        if (!math.isFinite(elem)) return Error.UnsupportedInput;
 
         try histogram.insert(index, elem);
     }
@@ -149,7 +149,7 @@ pub fn decompressPWCH(
 ) Error!void {
     // The compressed representation is pairs containing a 64-bit float value
     // and 64-bit integer end index.
-    if (compressed_values.len % 16 != 0) return Error.IncorrectInput;
+    if (compressed_values.len % 16 != 0) return Error.UnsupportedInput;
 
     const compressed_values_and_index = mem.bytesAsSlice(f64, compressed_values);
 
@@ -173,7 +173,7 @@ pub fn decompressPWLH(
 ) Error!void {
     // The compressed representation is composed of three values: (start_value, end_value, end_time)
     // all of type 64-bit float.
-    if (compressed_values.len % 24 != 0) return Error.IncorrectInput;
+    if (compressed_values.len % 24 != 0) return Error.UnsupportedInput;
 
     const compressed_lines_and_index = mem.bytesAsSlice(f64, compressed_values);
 

--- a/src/functional/histogram_compression.zig
+++ b/src/functional/histogram_compression.zig
@@ -73,6 +73,9 @@ pub fn compressPWCH(
     defer histogram.deinit();
 
     for (uncompressed_values, 0..) |elem, index| {
+        // Check if the current point is NaN or infinite. If so, return an error.
+        if (!math.isFinite(elem)) return Error.InvalidInput;
+
         try histogram.insert(index, elem);
     }
 
@@ -108,6 +111,9 @@ pub fn compressPWLH(
     defer histogram.deinit();
 
     for (uncompressed_values, 0..) |elem, index| {
+        // Check if the current point is NaN or infinite. If so, return an error.
+        if (!math.isFinite(elem)) return Error.InvalidInput;
+
         try histogram.insert(index, elem);
     }
 

--- a/src/functional/poor_mans_compression.zig
+++ b/src/functional/poor_mans_compression.zig
@@ -104,7 +104,7 @@ pub fn decompress(
     decompressed_values: *ArrayList(f64),
 ) Error!void {
     // The compressed representation is pairs containing a 64-bit float value and 64-bit end index.
-    if (compressed_values.len % 16 != 0) return Error.IncorrectInput;
+    if (compressed_values.len % 16 != 0) return Error.UnsupportedInput;
 
     const compressed_values_and_index = mem.bytesAsSlice(f64, compressed_values);
 

--- a/src/functional/sim_piece.zig
+++ b/src/functional/sim_piece.zig
@@ -200,7 +200,7 @@ fn computeSegmentsMetadata(
     var lower_bound_slope: f64 = -math.floatMax(f64);
 
     // Check if the first point is NaN or infinite. If so, return an error.
-    if (!math.isFinite(uncompressed_values[0])) return Error.InvalidInput;
+    if (!math.isFinite(uncompressed_values[0])) return Error.UnsupportedInput;
 
     // Initialize the `start_point` with the first uncompressed value.
     var start_point: DiscretePoint = .{ .time = 0, .value = uncompressed_values[0] };
@@ -214,7 +214,7 @@ fn computeSegmentsMetadata(
     for (1..uncompressed_values.len) |current_timestamp| {
 
         // Check if the current point is NaN or infinite. If so, return an error.
-        if (!math.isFinite(uncompressed_values[current_timestamp])) return Error.InvalidInput;
+        if (!math.isFinite(uncompressed_values[current_timestamp])) return Error.UnsupportedInput;
 
         const end_point: DiscretePoint = .{
             .time = current_timestamp,

--- a/src/functional/sim_piece.zig
+++ b/src/functional/sim_piece.zig
@@ -192,12 +192,15 @@ fn computeSegmentsMetadata(
     uncompressed_values: []const f64,
     segments_metadata: *ArrayList(SegmentMetadata),
     error_bound: f32,
-) !void {
+) Error!void {
     // Adjust the error bound to avoid exceeding it during decompression.
     const adjusted_error_bound = error_bound - shared.ErrorBoundMargin;
 
     var upper_bound_slope: f64 = math.floatMax(f64);
     var lower_bound_slope: f64 = -math.floatMax(f64);
+
+    // Check if the first point is NaN or infinite. If so, return an error.
+    if (!math.isFinite(uncompressed_values[0])) return Error.InvalidInput;
 
     // Initialize the `start_point` with the first uncompressed value.
     var start_point: DiscretePoint = .{ .time = 0, .value = uncompressed_values[0] };
@@ -209,6 +212,10 @@ fn computeSegmentsMetadata(
 
     // The first point is already part of `current_segment`, the next point is at index one.
     for (1..uncompressed_values.len) |current_timestamp| {
+
+        // Check if the current point is NaN or infinite. If so, return an error.
+        if (!math.isFinite(uncompressed_values[current_timestamp])) return Error.InvalidInput;
+
         const end_point: DiscretePoint = .{
             .time = current_timestamp,
             .value = uncompressed_values[current_timestamp],

--- a/src/functional/swing_slide_filter.zig
+++ b/src/functional/swing_slide_filter.zig
@@ -58,7 +58,7 @@ pub fn compressSwingFilter(
     uncompressed_values: []const f64,
     compressed_values: *ArrayList(u8),
     error_bound: f32,
-) !void {
+) Error!void {
     // Adjust the error bound to avoid exceeding it during decompression due to numerical
     // inestabilities. This can happen if the linear approximation is equal to one of the
     // upper or lower bounds.
@@ -73,6 +73,9 @@ pub fn compressSwingFilter(
     var lower_bound: LinearFunction = .{ .slope = undefined, .intercept = undefined };
     var new_upper_bound: LinearFunction = .{ .slope = undefined, .intercept = undefined };
     var new_lower_bound: LinearFunction = .{ .slope = undefined, .intercept = undefined };
+
+    // Check if the first two points are NaN or infinite. If so, return an error.
+    if (!(math.isFinite(uncompressed_values[0]) and math.isFinite(uncompressed_values[1]))) return Error.InvalidInput;
 
     // Initialize the current segment with first two points.
     var current_segment: Segment = .{
@@ -97,6 +100,10 @@ pub fn compressSwingFilter(
         const upper_limit = evaluateLinearFunctionAtTime(upper_bound, usize, current_timestamp);
         const lower_limit = evaluateLinearFunctionAtTime(lower_bound, usize, current_timestamp);
         var end_value: f64 = 0;
+
+        // Check if the current point is NaN or infinite. If so, return an error.
+        if (!math.isFinite(uncompressed_values[current_timestamp])) return Error.InvalidInput;
+
         if ((upper_limit < (uncompressed_values[current_timestamp] - adjusted_error_bound)) or
             (lower_limit > (uncompressed_values[current_timestamp] + adjusted_error_bound)))
         {
@@ -140,7 +147,8 @@ pub fn compressSwingFilter(
             current_segment.start_point.time = current_timestamp - 1;
             current_segment.start_point.value = end_value;
 
-            // Edge case as only one point is left.
+            // Check if there is only one point left. If so, update only the `end_point`.
+            // Otherwise, update the `end_point`, the upper and lower bounds and the `current_timestamp`.
             if (current_timestamp < uncompressed_values.len) {
                 current_segment.end_point.time = current_timestamp;
                 current_segment.end_point.value = uncompressed_values[current_timestamp];
@@ -236,7 +244,7 @@ pub fn compressSlideFilter(
     compressed_values: *ArrayList(u8),
     allocator: mem.Allocator,
     error_bound: f32,
-) !void {
+) Error!void {
 
     // Adjust the error bound to avoid exceeding it during decompression due to numerical
     // inestabilities. This can happen if the linear approximation is equal to one of the
@@ -259,6 +267,9 @@ pub fn compressSlideFilter(
     var lower_bound: LinearFunction = .{ .slope = undefined, .intercept = undefined };
     var new_upper_bound: LinearFunction = .{ .slope = undefined, .intercept = undefined };
     var new_lower_bound: LinearFunction = .{ .slope = undefined, .intercept = undefined };
+
+    // Check if the first two points are NaN or infinite. If so, return an error.
+    if (!(math.isFinite(uncompressed_values[0]) and math.isFinite(uncompressed_values[1]))) return Error.InvalidInput;
 
     // Initialize the current segment with first two points.
     var current_segment: Segment = .{
@@ -294,6 +305,9 @@ pub fn compressSlideFilter(
             usize,
             current_timestamp,
         );
+
+        // Check if the point at the current timestamp is NaN or infinite. If so, return an error.
+        if (!math.isFinite(uncompressed_values[current_timestamp])) return Error.InvalidInput;
 
         if ((upper_limit < (uncompressed_values[current_timestamp] - adjusted_error_bound)) or
             (lower_limit > (uncompressed_values[current_timestamp] + adjusted_error_bound)))
@@ -344,6 +358,10 @@ pub fn compressSlideFilter(
 
             // Edge case as only one point is left.
             if (current_timestamp + 1 < uncompressed_values.len) {
+
+                // Check if the point at the current timestamp is NaN or infinite. If so, return an error.
+                if (!math.isFinite(uncompressed_values[current_timestamp + 1])) return Error.InvalidInput;
+
                 // Update the current segment.
                 current_segment.end_point = .{
                     .time = current_timestamp + 1,
@@ -443,7 +461,7 @@ pub fn compressSwingFilterDisconnected(
     uncompressed_values: []const f64,
     compressed_values: *ArrayList(u8),
     error_bound: f32,
-) !void {
+) Error!void {
     // Adjust the error bound to avoid exceeding it during decompression due to numerical
     // inestabilities. This can happen if the linear approximation is equal to one of the
     // upper or lower bounds.
@@ -451,6 +469,9 @@ pub fn compressSwingFilterDisconnected(
         error_bound - shared.ErrorBoundMargin
     else
         error_bound;
+
+    // Check if the first two points are NaN or infinite. If so, return an error.
+    if (!(math.isFinite(uncompressed_values[0]) and math.isFinite(uncompressed_values[1]))) return Error.InvalidInput;
 
     // Create the upper lower and upper bounds used throughout the function. They are uninitialized
     // as they will be modified throughout the function.
@@ -477,6 +498,9 @@ pub fn compressSwingFilterDisconnected(
         // Calculate the upper and lower bound linear functions at the current timestamp.
         const upper_limit = evaluateLinearFunctionAtTime(upper_bound, usize, current_timestamp);
         const lower_limit = evaluateLinearFunctionAtTime(lower_bound, usize, current_timestamp);
+
+        // Check if the current point is NaN or infinite. If so, return an error.
+        if (!math.isFinite(uncompressed_values[current_timestamp])) return Error.InvalidInput;
 
         if ((upper_limit < (uncompressed_values[current_timestamp] - adjusted_error_bound)) or
             (lower_limit > (uncompressed_values[current_timestamp] + adjusted_error_bound)))
@@ -523,6 +547,10 @@ pub fn compressSwingFilterDisconnected(
             // Check if there is only one point left. If so, update only the `end_point`.
             // Otherwise, update the `end_point`, the upper and lower bounds and the `current_timestamp`.
             if (current_timestamp + 1 < uncompressed_values.len) {
+
+                // Check if the current point is NaN or infinite. If so, return an error.
+                if (!math.isFinite(uncompressed_values[current_timestamp + 1])) return Error.InvalidInput;
+
                 current_segment.end_point.time = current_timestamp + 1;
                 current_segment.end_point.value = uncompressed_values[current_timestamp + 1];
 
@@ -836,7 +864,7 @@ fn usizeToF80(value: usize) f80 {
 test "swing filter can always compress and decompress" {
     const allocator = testing.allocator;
     try tester.testGenerateCompressAndDecompress(
-        tester.generateRandomValues,
+        tester.generateNumericRandomValues,
         allocator,
         Method.SwingFilter,
         0,
@@ -847,7 +875,7 @@ test "swing filter can always compress and decompress" {
 test "swing filter disconnected can always compress and decompress" {
     const allocator = testing.allocator;
     try tester.testGenerateCompressAndDecompress(
-        tester.generateRandomValues,
+        tester.generateNumericRandomValues,
         allocator,
         Method.SwingFilterDisconnected,
         0,
@@ -858,12 +886,34 @@ test "swing filter disconnected can always compress and decompress" {
 test "slide filter disconnected can always compress and decompress" {
     const allocator = testing.allocator;
     try tester.testGenerateCompressAndDecompress(
-        tester.generateRandomValues,
+        tester.generateNumericRandomValues,
         allocator,
         Method.SlideFilter,
         0,
         tersets.isWithinErrorBound,
     );
+}
+
+test "swing and slide filter fail if NaN or infinite values are present" {
+    const allocator = testing.allocator;
+    var uncompressed_values = ArrayList(f64).init(allocator);
+    defer uncompressed_values.deinit();
+    var compressed_values = ArrayList(u8).init(allocator);
+    defer compressed_values.deinit();
+
+    try tester.generateBoundedRandomValues(&uncompressed_values, 0.0, 1.0, undefined);
+    try uncompressed_values.append(math.nan(f64));
+    try tester.generateBoundedRandomValues(&uncompressed_values, 0.0, 1.0, undefined);
+
+    compressSwingFilter(uncompressed_values.items, &compressed_values, 0.0) catch |err| {
+        try testing.expectEqual(err, Error.InvalidInput);
+    };
+    compressSwingFilterDisconnected(uncompressed_values.items, &compressed_values, 0.0) catch |err| {
+        try testing.expectEqual(err, Error.InvalidInput);
+    };
+    compressSlideFilter(uncompressed_values.items, &compressed_values, allocator, 0.0) catch |err| {
+        try testing.expectEqual(err, Error.InvalidInput);
+    };
 }
 
 test "swing filter zero error bound and even size compress and decompress" {

--- a/src/tersets.zig
+++ b/src/tersets.zig
@@ -32,6 +32,7 @@ pub const Error = error{
     UnsupportedErrorBound,
     OutOfMemory,
     EmptyConvexHull,
+    InvalidInput,
 };
 
 /// The compression methods in TerseTS.

--- a/src/tersets.zig
+++ b/src/tersets.zig
@@ -26,13 +26,11 @@ const piecewise_histogram = @import("functional/histogram_compression.zig");
 /// The errors that can occur in TerseTS.
 pub const Error = error{
     UnknownMethod,
-    ItemNotFound,
-    EmptyInput,
-    IncorrectInput,
+    UnsupportedInput,
     UnsupportedErrorBound,
+    ItemNotFound,
     OutOfMemory,
     EmptyConvexHull,
-    InvalidInput,
 };
 
 /// The compression methods in TerseTS.
@@ -57,7 +55,7 @@ pub fn compress(
     method: Method,
     error_bound: f32,
 ) Error!ArrayList(u8) {
-    if (uncompressed_values.len == 0) return Error.EmptyInput;
+    if (uncompressed_values.len == 0) return Error.UnsupportedInput;
     if (error_bound < 0) return Error.UnsupportedErrorBound;
 
     var compressed_values = ArrayList(u8).init(allocator);
@@ -135,7 +133,7 @@ pub fn decompress(
     compressed_values: []const u8,
     allocator: Allocator,
 ) Error!ArrayList(f64) {
-    if (compressed_values.len == 0) return Error.EmptyInput;
+    if (compressed_values.len == 0) return Error.UnsupportedInput;
 
     const method_index: u8 = compressed_values[compressed_values.len - 1];
     if (method_index > getMaxMethodIndex()) return Error.UnknownMethod;

--- a/src/tester.zig
+++ b/src/tester.zig
@@ -180,7 +180,11 @@ pub fn replaceNormalValues(
 pub fn generateRandomValues(uncompressed_values: *ArrayList(f64), random: Random) !void {
     for (0..number_of_values) |_| {
         // rand can only generate f64 values in the range [0, 1).
-        try uncompressed_values.append(@as(f64, @bitCast(random.int(u64))));
+        var random_value = @as(f64, @bitCast(random.int(u64)));
+        if (!std.math.isFinite(random_value))
+            random_value = 0.0;
+
+        try uncompressed_values.append(random_value);
     }
 }
 

--- a/src/tester.zig
+++ b/src/tester.zig
@@ -187,16 +187,16 @@ pub fn generateRandomValues(uncompressed_values: *ArrayList(f64), random: Random
 
 /// Generate `number_of_values` of random `f64` values for use in testing using `random` and add
 /// them to `uncompressed_values`. If the value is not finite, it is replaced with zero.
-pub fn generateNumericRandomValues(uncompressed_values: *ArrayList(f64), random: Random) !void {
-    for (0..number_of_values) |_| {
-        // rand can only generate f64 values in the range [0, 1).
-        var random_value = @as(f64, @bitCast(random.int(u64)));
-        if (!std.math.isFinite(random_value))
-            // Replace non-finite values (e.g., NaN, infinity) with 0.0 to ensure valid test data
-            // and avoid potential issues with downstream operations that may not handle them.
-            random_value = 0.0;
-
-        try uncompressed_values.append(random_value);
+pub fn generateFiniteRandomValues(uncompressed_values: *ArrayList(f64), random: Random) !void {
+    var index: usize = 0;
+    while (index < number_of_values) {
+        // rand can only generate f64 values in the range [0, 1), thus using u64.
+        const random_value = @as(f64, @bitCast(random.int(u64)));
+        // Online add finite values.
+        if (std.math.isFinite(random_value)) {
+            try uncompressed_values.append(random_value);
+            index += 1;
+        }
     }
 }
 

--- a/src/tester.zig
+++ b/src/tester.zig
@@ -180,8 +180,20 @@ pub fn replaceNormalValues(
 pub fn generateRandomValues(uncompressed_values: *ArrayList(f64), random: Random) !void {
     for (0..number_of_values) |_| {
         // rand can only generate f64 values in the range [0, 1).
+        const random_value = @as(f64, @bitCast(random.int(u64)));
+        try uncompressed_values.append(random_value);
+    }
+}
+
+/// Generate `number_of_values` of random `f64` values for use in testing using `random` and add
+/// them to `uncompressed_values`. If the value is not finite, it is replaced with zero.
+pub fn generateNumericRandomValues(uncompressed_values: *ArrayList(f64), random: Random) !void {
+    for (0..number_of_values) |_| {
+        // rand can only generate f64 values in the range [0, 1).
         var random_value = @as(f64, @bitCast(random.int(u64)));
         if (!std.math.isFinite(random_value))
+            // Replace non-finite values (e.g., NaN, infinity) with 0.0 to ensure valid test data
+            // and avoid potential issues with downstream operations that may not handle them.
             random_value = 0.0;
 
         try uncompressed_values.append(random_value);


### PR DESCRIPTION
This PR proposes a quick fix to the random generation process that was producing NaN values. These NaN values were later making the test fail, so in theory, now all tests should pass without problem. This PR closes issue #72.