### PR TITLE
Change f80 to f64

### DIFF
--- a/src/functional/histogram_compression.zig
+++ b/src/functional/histogram_compression.zig
@@ -192,7 +192,7 @@ pub fn decompressPWLH(
 
         if (current_segment.start_point.time < current_segment.end_point.time) {
             if (current_segment.end_point.time != current_segment.start_point.time) {
-                const duration: f80 = @floatFromInt(current_segment.end_point.time -
+                const duration: f64 = @floatFromInt(current_segment.end_point.time -
                     current_segment.start_point.time);
                 linear_approximation.slope = (current_segment.end_point.value -
                     current_segment.start_point.value) / duration;

--- a/src/functional/swing_slide_filter.zig
+++ b/src/functional/swing_slide_filter.zig
@@ -84,7 +84,7 @@ pub fn compressSwingFilter(
     };
 
     // Compute the numerator Eq. (6).
-    var slope_derivate: f80 = computeSlopeDerivate(current_segment);
+    var slope_derivate: f64 = computeSlopeDerivate(current_segment);
 
     updateSwingLinearFunction(current_segment, &upper_bound, adjusted_error_bound);
     updateSwingLinearFunction(current_segment, &lower_bound, -adjusted_error_bound);
@@ -111,12 +111,12 @@ pub fn compressSwingFilter(
             const segment_size = current_timestamp - current_segment.start_point.time - 1;
             if (segment_size > 1) {
                 // Denominator of Eq. (6).
-                const sum_square: f80 = @floatFromInt(
+                const sum_square: f64 = @floatFromInt(
                     segment_size * (segment_size + 1) * (2 * segment_size + 1) / 6,
                 );
 
                 // Get optimal slope that minimizes the squared error Eq. (5).
-                const slope: f80 = @max(
+                const slope: f64 = @max(
                     @min(slope_derivate / sum_square, upper_bound.slope),
                     lower_bound.slope,
                 );
@@ -204,12 +204,12 @@ pub fn compressSwingFilter(
 
     if (segment_size > 1) {
         // Denominator of Eq. (6).
-        const sum_square: f80 = @floatFromInt(
+        const sum_square: f64 = @floatFromInt(
             segment_size * (segment_size + 1) * (2 * segment_size + 1) / 6,
         );
 
         // Get optimal slope that minimizes the squared error Eq. (5).
-        const slope: f80 = @max(
+        const slope: f64 = @max(
             @min(slope_derivate / sum_square, upper_bound.slope),
             lower_bound.slope,
         );
@@ -487,7 +487,7 @@ pub fn compressSwingFilterDisconnected(
     };
 
     // Compute the numerator Eq. (6).
-    var slope_derivate: f80 = computeSlopeDerivate(current_segment);
+    var slope_derivate: f64 = computeSlopeDerivate(current_segment);
 
     updateSwingLinearFunction(current_segment, &upper_bound, adjusted_error_bound);
     updateSwingLinearFunction(current_segment, &lower_bound, -adjusted_error_bound);
@@ -510,12 +510,12 @@ pub fn compressSwingFilterDisconnected(
             const segment_size = current_timestamp - current_segment.start_point.time - 1;
             if (segment_size > 1) {
                 // Denominator of Eq. (6).
-                const sum_square: f80 = @floatFromInt(
+                const sum_square: f64 = @floatFromInt(
                     segment_size * (segment_size + 1) * (2 * segment_size + 1) / 6,
                 );
 
                 // Get optimal slope that minimizes the squared error Eq. (5).
-                const slope: f80 = @max(
+                const slope: f64 = @max(
                     @min(slope_derivate / sum_square, upper_bound.slope),
                     lower_bound.slope,
                 );
@@ -609,12 +609,12 @@ pub fn compressSwingFilterDisconnected(
     // Check if the last segment has more than one point. If so, the recording mechanism is triggered.
     if (segment_size > 1) {
         // Denominator of Eq. (6).
-        const sum_square: f80 = @floatFromInt(
+        const sum_square: f64 = @floatFromInt(
             segment_size * (segment_size + 1) * (2 * segment_size + 1) / 6,
         );
 
         // Get optimal slope that minimizes the squared error Eq. (5).
-        const slope: f80 = @max(
+        const slope: f64 = @max(
             @min(slope_derivate / sum_square, upper_bound.slope),
             lower_bound.slope,
         );
@@ -755,9 +755,9 @@ pub fn decompressSlideFilter(
 }
 
 /// Computes the numerator of the slope derivate as in Eq. (6).
-fn computeSlopeDerivate(segment: Segment) f80 {
+fn computeSlopeDerivate(segment: Segment) f64 {
     return (segment.end_point.value - segment.start_point.value) *
-        usizeToF80(segment.end_point.time - segment.start_point.time);
+        usizeToF64(segment.end_point.time - segment.start_point.time);
 }
 
 /// Updates the linear function coeficients in `linear_function` that passes throught the two
@@ -769,11 +769,11 @@ fn updateSwingLinearFunction(
     error_bound: f32,
 ) void {
     if (segment.end_point.time != segment.start_point.time) {
-        const duration: f80 = @floatFromInt(segment.end_point.time - segment.start_point.time);
+        const duration: f64 = @floatFromInt(segment.end_point.time - segment.start_point.time);
         linear_function.slope = (segment.end_point.value + error_bound -
             segment.start_point.value) / duration;
         linear_function.intercept = segment.start_point.value - linear_function.slope *
-            usizeToF80(segment.start_point.time);
+            usizeToF64(segment.start_point.time);
     } else {
         linear_function.slope = 0.0;
         linear_function.intercept = segment.start_point.value;
@@ -787,7 +787,7 @@ fn evaluateLinearFunctionAtTime(
     time: time_type,
 ) f64 {
     if (time_type == usize) {
-        return @floatCast(linear_function.slope * usizeToF80(time) + linear_function.intercept);
+        return @floatCast(linear_function.slope * usizeToF64(time) + linear_function.intercept);
     } else {
         return @floatCast(linear_function.slope * time + linear_function.intercept);
     }
@@ -807,9 +807,9 @@ fn appendValue(comptime T: type, value: T, compressed_values: *std.ArrayList(u8)
 
 /// Computes the intercept coefficient of a linear function that passes through the `DiscretePoint`
 /// `point` with the given `slope` coefficient.
-fn computeInterceptCoefficient(slope: f80, comptime point_type: type, point: point_type) f80 {
+fn computeInterceptCoefficient(slope: f64, comptime point_type: type, point: point_type) f64 {
     if (point_type == DiscretePoint) {
-        return point.value - slope * usizeToF80(point.time);
+        return point.value - slope * usizeToF64(point.time);
     } else {
         return point.value - slope * point.time;
     }
@@ -826,11 +826,11 @@ fn updateSlideLinearFunction(
     error_bound: f32,
 ) void {
     if (segment.end_point.time != segment.start_point.time) {
-        const duration: f80 = @floatFromInt(segment.end_point.time - segment.start_point.time);
+        const duration: f64 = @floatFromInt(segment.end_point.time - segment.start_point.time);
         linear_function.slope = (segment.end_point.value + 2 * error_bound -
             segment.start_point.value) / duration;
         linear_function.intercept = segment.start_point.value - error_bound -
-            linear_function.slope * usizeToF80(segment.start_point.time);
+            linear_function.slope * usizeToF64(segment.start_point.time);
     } else {
         linear_function.slope = 0.0;
         linear_function.intercept = segment.start_point.value;
@@ -856,9 +856,9 @@ fn computeInterceptionPoint(
     }
 }
 
-/// Converts `value` of `usize` to `f80`.
-fn usizeToF80(value: usize) f80 {
-    return @as(f80, @floatFromInt(value));
+/// Converts `value` of `usize` to `f64`.
+fn usizeToF64(value: usize) f64 {
+    return @as(f64, @floatFromInt(value));
 }
 
 test "swing filter can always compress and decompress" {

--- a/src/utilities/convex_hull.zig
+++ b/src/utilities/convex_hull.zig
@@ -118,9 +118,9 @@ pub const ConvexHull = struct {
         if (convex_hull_len == 2) {
             const first_point = self.at(0);
             const second_point = self.at(1);
-            const delta_time: f80 = @floatFromInt(second_point.time - first_point.time);
+            const delta_time: f64 = @floatFromInt(second_point.time - first_point.time);
             const slope = (second_point.value - first_point.value) / delta_time;
-            const intercept_value: f80 = first_point.value - slope * @as(f80, @floatFromInt(first_point.time));
+            const intercept_value: f64 = first_point.value - slope * @as(f64, @floatFromInt(first_point.time));
             return LinearFunction{
                 .slope = slope,
                 .intercept = intercept_value,

--- a/src/utilities/shared_structs.zig
+++ b/src/utilities/shared_structs.zig
@@ -34,8 +34,8 @@ pub const Segment = struct {
 
 /// Linear function of the form y = slope*x+intercept. It uses f80 for numerical stability.
 pub const LinearFunction = struct {
-    slope: f80,
-    intercept: f80,
+    slope: f64,
+    intercept: f64,
 };
 
 /// `Point` is a point represented by `time` and `value`. `time` is of datatype `time_type`.


### PR DESCRIPTION
This PR changes the use of f80 to f64 in the Line Function structure and closes to #64. Turns out that this was adding unnecessary casting around the code, while not needed to ensure the error bound, evident since all tests are passing.