### PR TITLE
Add support for compression parametrization

### DIFF
--- a/bindings/c/tersets.h
+++ b/bindings/c/tersets.h
@@ -1,32 +1,124 @@
+// Copyright 2024 TerseTS Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TERSETS_H
+#define TERSETS_H
+
 #include <stdint.h>
+#include <stddef.h> // for size_t
 
-// A pointer to uncompressed values and the number of values.
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// -----------------------------------------------------------------------------
+// Data Structures
+// -----------------------------------------------------------------------------
+
+/// A pointer to uncompressed values and the number of values.
 struct UncompressedValues {
-  double const * const data;
-  uintptr_t const len;
+    const double* data;
+    uintptr_t len;
 };
 
-// A pointer to compressed values and the number of bytes.
+/// A pointer to compressed values and the number of bytes.
 struct CompressedValues {
-  uint8_t const * const data;
-  uintptr_t const len;
+    const uint8_t* data;
+    uintptr_t len;
 };
 
-// Configuration to use for compression and/or decompression.
+/// The type of error bound used in compression algorithms.
+enum ErrorBoundType {
+    TERSETS_ERROR_BOUND_ABSOLUTE,
+    TERSETS_ERROR_BOUND_RELATIVE,
+};
+
+/// Cost function used in line simplification algorithms.
+enum CostFunction{
+    TERSETS_ERROR_BOUND_RMSE,
+    TERSETS_ERROR_BOUND_LINF,
+};
+
+/// Error codes returned by TerseTS compression and decompression functions.
+enum TerseTSError {
+    TERSETS_ERROR_UNKNOWN_METHOD         = 1,
+    TERSETS_ERROR_UNSUPPORTED_INPUT      = 2,
+    TERSETS_ERROR_UNSUPPORTED_ERROR_BOUND= 3,
+    TERSETS_ERROR_UNSUPPORTED_PARAMETERS = 4,
+    TERSETS_ERROR_ITEM_NOT_FOUND         = 5,
+    TERSETS_ERROR_OUT_OF_MEMORY          = 6,
+    TERSETS_ERROR_EMPTY_CONVEX_HULL      = 7,
+    TERSETS_ERROR_EMPTY_QUEUE            = 8,
+};
+
+/// Configuration to use for compression and decompression.
+/// - `method`: the compression algorithm (enum value).
+/// - `parameters`: a pointer to a method-specific struct 
+//     (e.g., `FunctionalParams`) or a `BasicParams`. 
 struct Configuration {
-  uint8_t const method;
-  float const error_bound;
+    uint8_t method;
+    const void* parameters;
 };
 
-// Compress uncompressed_values to compressed_values according to
-// configuration. The following non-zero values are returned on errors:
-// - 1) Unsupported compression method.
-int32_t compress(struct UncompressedValues const uncompressed_values,
-                 struct CompressedValues *const compressed_values,
-                 struct Configuration const configuration);
+// -----------------------------------------------------------------------------
+// Parameter Structs
+// -----------------------------------------------------------------------------
 
-// Decompress compressed_values to uncompressed_values according to
-// configuration. The following non-zero values are returned on errors:
-// - 1) Unsupported decompression method.
-int32_t decompress(struct CompressedValues const compressed_values,
-                   struct UncompressedValues const * const uncompressed_values);
+/// Basic fallback parameters — used when `is_default = 1`.
+struct BasicParams {
+    float error_bound;
+};
+
+/// Histogram-based compression parameters.
+struct HistogramParams {
+    size_t maximum_buckets;
+};
+
+/// Functional approximation parameters (e.g. linear/piecewise regression).
+struct FunctionalParams {
+    enum ErrorBoundType error_bound_type;
+    float error_bound;
+};
+
+/// Line simplification parameters (e.g. Visvalingam-Whyatt).
+struct LineSimplificationParams {
+    enum ErrorBoundType error_bound_type;
+    float error_bound;
+};
+
+// -----------------------------------------------------------------------------
+// API Functions
+// -----------------------------------------------------------------------------
+
+/// Compress `uncompressed_values` into `compressed_values` using `configuration`.
+/// Returns 0 on success, or a `TerseTSError` on failure.
+int32_t compress(
+    struct UncompressedValues uncompressed_values,
+    struct CompressedValues* compressed_values,
+    struct Configuration configuration);
+
+/// Decompress `compressed_values` into `uncompressed_values`.
+/// Returns 0 on success, or a `TerseTSError` on failure.
+int32_t decompress(
+    struct CompressedValues compressed_values,
+    struct UncompressedValues* uncompressed_values);
+
+/// Returns a human-readable error message for a given `TerseTSError` code.
+const char* tersets_strerror(int32_t code);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TERSETS_H

--- a/bindings/python/tersets/__init__.py
+++ b/bindings/python/tersets/__init__.py
@@ -18,64 +18,99 @@ import sys
 import pathlib
 import sysconfig
 from typing import List
-from enum import Enum, unique
-from ctypes import cdll, Structure, c_byte, c_float, c_double, c_size_t, POINTER, byref
+from typing import Union
+from enum import Enum, IntEnum, unique
+from ctypes import (
+    cdll,
+    Structure,
+    c_byte,
+    c_uint8,
+    c_float,
+    c_double,
+    c_size_t,
+    c_void_p,
+    POINTER,
+    byref,
+    cast,
+    c_int32,
+)
 
+# -----------------------------------------------------------------------------
+# Internal: Load the shared library
+# -----------------------------------------------------------------------------
 
-# Private Functions.
 def __load_library():
-    """Locates the correct library for this system and loads it."""
-
     if sys.platform == "win32":
-        # SHLIB_SUFFIX is not set and .pyd is used by build.
         library_name = "tersets.pyd"
     else:
         library_name = "tersets" + sysconfig.get_config_var("SHLIB_SUFFIX")
 
-    # Attempt to load the library installed as part of the Python package.
     library_folder = pathlib.Path(__file__).parent.parent.resolve()
     library_path = library_folder / library_name
     if library_path.exists():
         return cdll.LoadLibrary(str(library_path))
 
-    # Attempt to load the library compiled in the development repository.
+    # Fallback: use Zig build location.
     repository_root = pathlib.Path(__file__).parent.parent.parent.parent.resolve()
-    library_folder = repository_root / "zig-out" / "lib"
-
     if sys.platform == "win32":
-        # SHLIB_SUFFIX is not set and .dll is used by Zig.
-        library_name = "tersets.dll"
-        library_folder = repository_root / "zig-out" / "bin"
+        library_path = repository_root / "zig-out" / "bin" / "tersets.dll"
     elif sys.platform == "darwin":
-        # SHLIB_SUFFIX is set to .so but macOS uses .dylib.
-        library_name = "tersets.dylib"
+        library_path = repository_root / "zig-out" / "lib" / "tersets.dylib"
+    else:
+        library_path = repository_root / "zig-out" / "lib" / library_name
 
-    library_path = next(library_folder.glob("*" + library_name))
-    if library_path.exists():
-        return cdll.LoadLibrary(str(library_path))
+    return cdll.LoadLibrary(str(library_path))
 
-
-# A global variable is used for the library so it is only initialized once and
-# can be easily used by the public functions without users having to pass it.
 __library = __load_library()
 
+# -----------------------------------------------------------------------------
+# C Structs & Enums
+# -----------------------------------------------------------------------------
 
-# Private Types.
-class __UncompressedValues(Structure):
+class ErrorBoundType(IntEnum):
+    ABS = 0
+    RELATIVE = 1
+
+class CostFunction(IntEnum):
+    RMSE = 0
+    LINF = 1
+
+class _UncompressedValues(Structure):
     _fields_ = [("data", POINTER(c_double)), ("len", c_size_t)]
 
-
-class __CompressedValues(Structure):
+class _CompressedValues(Structure):
     _fields_ = [("data", POINTER(c_byte)), ("len", c_size_t)]
 
+class BasicParams(Structure):
+    _fields_ = [
+        ("error_bound", c_float),
+    ]
 
-class __Configuration(Structure):
-    _fields_ = [("method", c_byte), ("error_bound", c_float)]
+class FunctionalParams(Structure):
+    _fields_ = [
+        ("error_bound_type", c_uint8),  # ErrorBoundType
+        ("error_bound", c_float),
+    ]
 
+class HistogramParams(Structure):
+    _fields_ = [
+        ("maximum_buckets", c_size_t),
+    ]
 
-# Mirror TerseTS Method Enum.
+class LineSimplificationParams(Structure):
+    _fields_ = [
+        ("cost_function", c_uint8),  # CostFunction
+        ("error_bound", c_float),
+    ]
+
+class _Configuration(Structure):
+    _fields_ = [
+        ("method", c_uint8),
+        ("parameters", c_void_p),
+    ]
+
 @unique
-class Method(Enum):
+class Method(IntEnum):
     PoorMansCompressionMidrange = 0
     PoorMansCompressionMean = 1
     SwingFilter = 2
@@ -85,48 +120,92 @@ class Method(Enum):
     PiecewiseConstantHistogram = 6
     PiecewiseLinearHistogram = 7
     VisvalingamWhyatt = 8
+    IdentityCompression = 9
 
-# Public Functions.
-def compress(values: List[float], method: Method, error_bound: float) -> bytes:
-    """Compresses values."""
+@unique
+class TerseTSError(IntEnum):
+    UnknownMethod = 1
+    UnsupportedInput = 2
+    UnsupportedErrorBound = 3
+    UnsupportedParameters = 4
+    ItemNotFound = 5
+    OutOfMemory = 6
+    EmptyConvexHull = 7
+    EmptyQueue = 8
 
-    uncompressed_values = __UncompressedValues()
-    uncompressed_values.data = (c_double * len(values))(*values)
+_error_messages = {
+    1: "Unknown compression method.",
+    2: "Unsupported or empty input.",
+    3: "Unsupported or negative error bound.",
+    4: "Unsupported or missing configuration parameters.",
+    5: "Item not found during decompression.",
+    6: "Out of memory.",
+    7: "Convex hull was empty.",
+    8: "Internal queue was unexpectedly empty.",
+}
+
+# -----------------------------------------------------------------------------
+# Function Signatures
+# -----------------------------------------------------------------------------
+
+__library.compress.argtypes = [_UncompressedValues, POINTER(_CompressedValues), _Configuration]
+__library.compress.restype = c_int32
+
+__library.decompress.argtypes = [_CompressedValues, POINTER(_UncompressedValues)]
+__library.decompress.restype = c_int32
+
+# -----------------------------------------------------------------------------
+# Public API
+# -----------------------------------------------------------------------------
+
+def compress(values: List[float], method: Method, params: Union[float, BasicParams, FunctionalParams, HistogramParams, LineSimplificationParams]) -> bytes:
+    """Compress a list of floats using the specified method and parameter configuration.
+
+    You may pass:
+    - a float error_bound (used as BasicParams)
+    - an instance of a full parameter struct (e.g., FunctionalParams)
+    """
+    if not isinstance(method, Method):
+        raise TypeError(f"Invalid method: {method}")
+
+    # Convert float to BasicParams if needed
+    if isinstance(params, float):
+        params_struct = BasicParams(error_bound=params)
+    elif isinstance(params, (BasicParams, FunctionalParams, HistogramParams, LineSimplificationParams)):
+        params_struct = params
+        is_default = 0
+    else:
+        raise TypeError(f"Invalid params type: {type(params)}")
+
+    # Set up uncompressed values
+    array_type = c_double * len(values)
+    uncompressed_values = _UncompressedValues()
+    uncompressed_values.data = array_type(*values)
     uncompressed_values.len = len(values)
 
-    compressed_values = __CompressedValues()
-
-    if type(method) != Method:
-        # Method does not exists, raise error, and show available options.
-        available_methods = ", ".join([member.name for member in Method])
-        raise TypeError(
-            f"'{method}' is not a valid TerseTS Method. Available method names are: {available_methods}"
-        )
-
-    configuration = __Configuration(method.value, error_bound)
-
-    error = __library.compress(
-        uncompressed_values, byref(compressed_values), configuration
+    compressed_values = _CompressedValues()
+    config = _Configuration(
+        method=method.value,
+        is_default=is_default,
+        parameters=cast(c_void_p, byref(params_struct))
     )
 
-    if error == 1:
-        raise ValueError("Unknown error.")
+    err = __library.compress(uncompressed_values, byref(compressed_values), config)
+    if err != 0:
+        raise RuntimeError(_error_messages.get(err, f"Unknown error code: {err}"))
 
-    return compressed_values.data[: compressed_values.len]
+    return bytes(compressed_values.data[:compressed_values.len])
 
 
 def decompress(values: bytes) -> List[float]:
-    """Decompresses values."""
-
-    compressed_values = __CompressedValues()
+    """Decompress a byte sequence into a list of floats."""
+    compressed_values = _CompressedValues()
     compressed_values.data = (c_byte * len(values))(*values)
     compressed_values.len = len(values)
 
-    decompressed_values = __UncompressedValues()
+    decompressed_values = _UncompressedValues()
+    err = __library.decompress(compressed_values, byref(decompressed_values))
+    if err != 0:
+        raise RuntimeError(_error_messages.get(err, f"Unknown error code: {err}"))
 
-    error = __library.decompress(compressed_values, byref(decompressed_values))
-
-    if error == 1:
-        raise ValueError("Unknown decompression method.")
-
-    return decompressed_values.data[: decompressed_values.len]
+    return list(decompressed_values.data[:decompressed_values.len])

--- a/bindings/python/tests/__init__.py
+++ b/bindings/python/tests/__init__.py
@@ -16,7 +16,7 @@ import sys
 import random
 import unittest
 
-from tersets import compress, decompress, Method
+from tersets import compress, decompress, Method, FunctionalParams, ErrorBoundType
 
 # Number of values to generate for each test.
 TEST_VALUE_COUNT = 1000
@@ -27,6 +27,12 @@ class TerseTSPythonTest(unittest.TestCase):
             random.uniform(sys.float_info.min, sys.float_info.max)
             for _ in range(0, TEST_VALUE_COUNT)
         ]
-        compressed = compress(uncompressed, Method.SwingFilter, 0.0)
+        # Use FunctionalParams with relative error
+        params = FunctionalParams(
+            error_bound_type=ErrorBoundType.RELATIVE,
+            error_bound=0.0
+        )
+
+        compressed = compress(uncompressed, Method.SwingFilter, params)
         decompressed = decompress(compressed)
         self.assertEqual(uncompressed, decompressed)

--- a/src/capi.zig
+++ b/src/capi.zig
@@ -97,6 +97,21 @@ fn Array(comptime data_type: type) type {
     return extern struct { data: [*]const data_type, len: usize };
 }
 
+/// Returns a human-readable description of a TerseTS error code.
+export fn tersets_strerror(code: i32) [*:0]const u8 {
+    return switch (code) {
+        1 => "Unknown method",
+        2 => "Unsupported input",
+        3 => "Unsupported error bound",
+        4 => "Unsupported parameters",
+        5 => "Item not found",
+        6 => "Out of memory",
+        7 => "Empty convex hull",
+        8 => "Empty queue",
+        else => "Unknown error",
+    };
+}
+
 // Convert `err` to an `i32` as is not guaranteed to be stable `@intFromError`.
 fn errorToInt(err: Error) i32 {
     switch (err) {

--- a/src/functional/histogram_compression.zig
+++ b/src/functional/histogram_compression.zig
@@ -58,9 +58,9 @@ pub fn compressPWCH(
     uncompressed_values: []const f64,
     compressed_values: *ArrayList(u8),
     allocator: mem.Allocator,
-    error_bound: f32,
+    max_buckets: usize,
 ) Error!void {
-    if (error_bound <= 1.0) {
+    if (max_buckets <= 1.0) {
         return Error.UnsupportedErrorBound;
     }
 
@@ -68,7 +68,6 @@ pub fn compressPWCH(
     // by a usize instead of `error_bound: f32`. Changing this requires modifications in
     // `src/tersets.zig` and `src/capi.zig` files.
     // TODO: Find the right way of passing the maximum number of buckets.
-    const max_buckets: usize = @as(usize, @intFromFloat(@floor(error_bound)));
     var histogram = try Histogram.init(allocator, max_buckets, .constant);
     defer histogram.deinit();
 
@@ -96,9 +95,9 @@ pub fn compressPWLH(
     uncompressed_values: []const f64,
     compressed_values: *ArrayList(u8),
     allocator: mem.Allocator,
-    error_bound: f32,
+    max_buckets: usize,
 ) Error!void {
-    if (error_bound <= 1.0) {
+    if (max_buckets <= 1.0) {
         return Error.UnsupportedErrorBound;
     }
 
@@ -106,7 +105,6 @@ pub fn compressPWLH(
     // by a usize instead of `error_bound: f32`. Changing this requires modifications in
     // `src/tersets.zig` and `src/capi.zig` files.
     // TODO: Find the right way of passing the maximum number of buckets.
-    const max_buckets: usize = @as(usize, @intFromFloat(@floor(error_bound)));
     var histogram = try Histogram.init(allocator, max_buckets, .linear);
     defer histogram.deinit();
 

--- a/src/functional/sim_piece.zig
+++ b/src/functional/sim_piece.zig
@@ -628,19 +628,17 @@ test "hashmap can map f64 to segment metadata array list" {
 }
 
 test "sim-piece can compress, decompress and merge many segments with non-zero error bound" {
-    const seed: u64 = @bitCast(time.milliTimestamp());
-    var prng = rand.DefaultPrng.init(seed);
-    const random = prng.random();
-    const error_bound = 0.1;
-
     const allocator = testing.allocator;
+
+    const error_bound = tester.generateBoundedRandomValue(f32, 0, 3, undefined);
+
     var uncompressed_values = ArrayList(f64).init(allocator);
     defer uncompressed_values.deinit();
 
     for (0..20) |_| {
         // Generate floating points numbers between 0 and 10. This will generate many merged
         // segments when applying Sim-Piece.
-        try tester.generateBoundedRandomValues(&uncompressed_values, 0, 10, random);
+        try tester.generateBoundedRandomValues(&uncompressed_values, 0, 10, undefined);
     }
 
     try tester.testCompressAndDecompress(
@@ -653,15 +651,12 @@ test "sim-piece can compress, decompress and merge many segments with non-zero e
 }
 
 test "sim-piece even size compress and decompress" {
-    const seed: u64 = @bitCast(time.milliTimestamp());
-    var prng = rand.DefaultPrng.init(seed);
-    const random = prng.random();
-    const error_bound = 0.01;
-
     const allocator = testing.allocator;
+    const error_bound = tester.generateBoundedRandomValue(f32, 0, 1, undefined);
+
     var uncompressed_values = ArrayList(f64).init(allocator);
     defer uncompressed_values.deinit();
-    try tester.generateBoundedRandomValues(&uncompressed_values, 0.0, 1.0, random);
+    try tester.generateBoundedRandomValues(&uncompressed_values, 0.0, 1.0, undefined);
 
     try tester.testCompressAndDecompress(
         uncompressed_values.items,
@@ -673,18 +668,15 @@ test "sim-piece even size compress and decompress" {
 }
 
 test "sim-piece odd size compress and decompress" {
-    const seed: u64 = @bitCast(time.milliTimestamp());
-    var prng = rand.DefaultPrng.init(seed);
-    const random = prng.random();
-    const error_bound = 0.01;
-
     const allocator = testing.allocator;
+    const error_bound = tester.generateBoundedRandomValue(f32, 0, 1, undefined);
+
     var uncompressed_values = ArrayList(f64).init(allocator);
     defer uncompressed_values.deinit();
-    try tester.generateBoundedRandomValues(&uncompressed_values, 0.0, 1.0, random);
+    try tester.generateBoundedRandomValues(&uncompressed_values, 0.0, 1.0, undefined);
 
     // Add another element to make the uncompressed values of odd size.
-    try uncompressed_values.append(random.float(f64));
+    try uncompressed_values.append(tester.generateBoundedRandomValue(f64, 0, 1, undefined));
 
     try tester.testCompressAndDecompress(
         uncompressed_values.items,
@@ -696,17 +688,14 @@ test "sim-piece odd size compress and decompress" {
 }
 
 test "sim-piece random lines and error bound compress and decompress" {
-    const seed: u64 = @bitCast(time.milliTimestamp());
-    var prng = rand.DefaultPrng.init(seed);
-    const random = prng.random();
-    const error_bound = 0.01;
+    const error_bound = tester.generateBoundedRandomValue(f32, 0, 1, undefined);
 
     const allocator = testing.allocator;
     var uncompressed_values = ArrayList(f64).init(allocator);
     defer uncompressed_values.deinit();
 
     for (0..20) |_| {
-        try tester.generateRandomLinearFunction(&uncompressed_values, random);
+        try tester.generateRandomLinearFunction(&uncompressed_values, undefined);
     }
 
     try tester.testCompressAndDecompress(

--- a/src/lossless/identity.zig
+++ b/src/lossless/identity.zig
@@ -1,0 +1,55 @@
+// Copyright 2024 TerseTS Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const std = @import("std");
+const mem = std.mem;
+const ArrayList = std.ArrayList;
+
+const tersets = @import("../tersets.zig");
+const Method = tersets.Method;
+const Error = tersets.Error;
+
+const tester = @import("../tester.zig");
+
+/// Compresses the `uncompressed_values` using the identity function, i.e., it simply compies
+/// all elements to the `compressed_values`. If an error occurs it is returned.
+pub fn compress(
+    uncompressed_values: []const f64,
+    compressed_values: *ArrayList(u8),
+) Error!void {
+    for (uncompressed_values) |value| {
+        const value_as_bytes: [8]u8 = @bitCast(value);
+        try compressed_values.appendSlice(value_as_bytes[0..]);
+    }
+}
+
+/// Decompresses the `compressed_values` by decoding every element and writes the results in
+/// `decompressed_values`. If an error occurs it is returned.
+pub fn decompress(compressed_values: []const u8, decompressed_values: *ArrayList(f64)) Error!void {
+    const compressed_representation = mem.bytesAsSlice(f64, compressed_values);
+    for (compressed_representation) |value| {
+        try decompressed_values.append(value);
+    }
+}
+
+test "identity can compress and decompress" {
+    const allocator = std.testing.allocator;
+    try tester.testGenerateCompressAndDecompress(
+        tester.generateRandomValues,
+        allocator,
+        Method.IdentityCompression,
+        0,
+        tersets.isWithinErrorBound,
+    );
+}

--- a/src/params.zig
+++ b/src/params.zig
@@ -1,0 +1,76 @@
+// Copyright 2024 TerseTS Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides the parameters structures for all compression methods in TerseTS.
+
+const std = @import("std");
+const Method = @import("tersets.zig").Method;
+const Allocator = std.mem.Allocator;
+
+pub const ErrorBoundType = enum(u8) {
+    abs_error_bound,
+    relative_error_bound,
+    roo_mean_square_error,
+    l_infinity_norm,
+};
+
+pub const BasicParams = extern struct {
+    error_bound: f32,
+};
+
+pub const FunctionalParams = extern struct {
+    error_bound_type: ErrorBoundType,
+    error_bound: f32,
+};
+
+pub const LineSimplificationParams = extern struct {
+    error_bound_type: ErrorBoundType,
+    error_bound: f32,
+};
+
+pub const HistogramParams = extern struct {
+    maximum_buckets: usize,
+};
+
+/// Converts BasicParams into method-specific param struct, heap-allocating it.
+pub fn mapBasicParamsToMethodParams(
+    method: Method,
+    basic: *const BasicParams,
+) !?*const anyopaque {
+    switch (method) {
+        .PoorMansCompressionMidrange, .PoorMansCompressionMean, .SlideFilter, .SimPiece, .SwingFilter, .SwingFilterDisconnected => {
+            const concrete = FunctionalParams{
+                .error_bound_type = .abs_error_bound,
+                .error_bound = basic.error_bound,
+            };
+            return &concrete;
+        },
+        .PiecewiseConstantHistogram, .PiecewiseLinearHistogram => {
+            const concrete = HistogramParams{
+                .maximum_buckets = @intFromFloat(basic.error_bound),
+            };
+            return &concrete;
+        },
+        .VisvalingamWhyatt => {
+            const concrete = LineSimplificationParams{
+                .error_bound = basic.error_bound,
+                .error_bound_type = .roo_mean_square_error,
+            };
+            return &concrete;
+        },
+        .IdentityCompression => {
+            return null;
+        },
+    }
+}

--- a/src/params.zig
+++ b/src/params.zig
@@ -12,38 +12,67 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Provides the parameters structures for all compression methods in TerseTS.
+//! This module defines all compression parameter structures used in TerseTS.
+//! It provides strongly-typed, FFI-compatible structs for different compression methods,
+//! and a helper to convert from a generic `BasicParams` to method-specific parameters
+//! when default configuration is used.
 
 const std = @import("std");
 const Method = @import("tersets.zig").Method;
 const Allocator = std.mem.Allocator;
 
+/// The type of error metric used to control compression accuracy.
 pub const ErrorBoundType = enum(u8) {
+    /// Absolute error threshold.
     abs_error_bound,
+    /// Relative error threshold, typically a ratio.
     relative_error_bound,
-    roo_mean_square_error,
+};
+
+/// The cost function used to control compression process.
+pub const CostFunction = enum(u8) {
+    /// Root mean square error (RMSE).
+    root_mean_square_error,
+    /// L-infinity norm (maximum absolute error).
     l_infinity_norm,
 };
 
+/// A basic parameter structure used as a default for compression methods that only require a
+/// scalar error bound. This struct is often used when the user wants to compress a time series
+/// without configuring method-specific details.
 pub const BasicParams = extern struct {
+    /// The error bound used for compression, interpreted as absolute by default.
     error_bound: f32,
 };
 
+/// Parameters for methods using a functional approximation model, such as linear or piecewise
+/// regression techniques.
 pub const FunctionalParams = extern struct {
+    /// The type of error bound to apply.
     error_bound_type: ErrorBoundType,
+    /// The numeric threshold for the chosen error bound type.
     error_bound: f32,
 };
 
+/// Parameters for line simplification methods (e.g., Visvalingam-Whyatt).
 pub const LineSimplificationParams = extern struct {
-    error_bound_type: ErrorBoundType,
+    /// The type of cost function to apply.
+    cost_function: CostFunction,
+    /// The numeric error threshold.
     error_bound: f32,
 };
 
+/// Parameters for histogram-based compression methods.
 pub const HistogramParams = extern struct {
+    /// The maximum number of buckets to use in the histogram.
     maximum_buckets: usize,
 };
 
-/// Converts BasicParams into method-specific param struct, heap-allocating it.
+/// Converts a `BasicParams` structure to a method-specific parameter struct for a given
+/// compression `method`. This function is used internally to support default compression
+/// configurations where users supply only a basic error bound. If the method supports
+/// basic parameters, this function returns a pointer to the corresponding method-specific
+/// parameter struct. Otherwise, it returns `null`.
 pub fn mapBasicParamsToMethodParams(
     method: Method,
     basic: *const BasicParams,
@@ -65,7 +94,7 @@ pub fn mapBasicParamsToMethodParams(
         .VisvalingamWhyatt => {
             const concrete = LineSimplificationParams{
                 .error_bound = basic.error_bound,
-                .error_bound_type = .roo_mean_square_error,
+                .cost_function = .root_mean_square_error,
             };
             return &concrete;
         },


### PR DESCRIPTION
This PR addresses the issue described in #55. This PR introduces a unified and extensible compression API across Zig, C, and Python. Following the discussion in https://github.com/cmcuza/TerseTS/issues/55#issuecomment-2500030000, a new `Configuration` struct is used to encapsulate the compression method and its associated parameters. This includes support for method-specific parameter structs (e.g., `FunctionalParams`, `HistogramParams`, `LineSimplificationParams`) as well as a simplified fallback `BasicParams` for users who only want to specify an error bound. The new API automatically maps `BasicParams` to the appropriate method-specific configuration. All these new configurations are part of a new file called `params.zig`.
In addition to changes in Zig to adapt to these changes, the C interface has been updated to reflect this design with enums and structs. Python bindings now support both simple and advanced configurations, and the `compress()` function dynamically determines how to construct and pass the correct parameter struct. I think it looks good, but I know it will generate a lot of work and a few iterations before merging. 