### PR TITLE
Transition from `goto-bus-stop/setup-zig` to `mlugg/setup-zig`

### DIFF
--- a/.github/workflows/zig-build-lint-and-test-on-pr-and-push.yml
+++ b/.github/workflows/zig-build-lint-and-test-on-pr-and-push.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: goto-bus-stop/setup-zig@v2
+    - uses: mlugg/setup-zig@v1.7.1
       with:
         version: 0.14.0  # Use a stable Zig version
 
@@ -68,7 +68,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: goto-bus-stop/setup-zig@v2
+      - uses: mlugg/setup-zig@v1.7.1
 
       - name: Zig Fmt Check
         run: zig fmt --check .

--- a/.github/workflows/zig-build-lint-and-test-on-pr-and-push.yml
+++ b/.github/workflows/zig-build-lint-and-test-on-pr-and-push.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: mlugg/setup-zig@v1.7.1
+    - uses: mlugg/setup-zig@v2
       with:
         version: 0.14.0  # Use a stable Zig version
 
@@ -68,7 +68,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: mlugg/setup-zig@v1.7.1
-
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: 0.14.0  # Use a stable Zig version
       - name: Zig Fmt Check
         run: zig fmt --check .


### PR DESCRIPTION
This PR closes #53, transitioning our GitHub workflow actions from `goto-bus-stop/setup-zig` to `mlugg/setup-zig`.