### PR TITLE
Add Method enum synchronization test

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ int main() {
    printf("Uncompressed data length: %lu\n", uncompressed_values.len);
 
    // Configuration for compression.
-   // The supported compression methods are specified in tersets.zig.
-   // Method 2 is SwingFilter and 0.1 error bound.
-   struct Configuration config = {2, 0.1};
+   // The C-API mirrors the Method enum from tersets.zig.
+   // Use the SwingFilter method with an error bound of 0.1.
+   struct Configuration config = {SwingFilter, 0.1};
 
    // Prepare for compressed data.
    // The compressed values point to dynamically allocated data that should be deallocated.

--- a/bindings/c/tersets.h
+++ b/bindings/c/tersets.h
@@ -1,5 +1,21 @@
 #include <stdint.h>
 
+// Mirror the compression methods provided by TerseTS.
+enum Method {
+  PoorMansCompressionMidrange = 0,
+  PoorMansCompressionMean = 1,
+  SwingFilter = 2,
+  SwingFilterDisconnected = 3,
+  SlideFilter = 4,
+  SimPiece = 5,
+  PiecewiseConstantHistogram = 6,
+  PiecewiseLinearHistogram = 7,
+  ABCLinearApproximation = 8,
+  VisvalingamWhyatt = 9,
+  SlidingWindow = 10,
+  BottomUp = 11,
+};
+
 // A pointer to uncompressed values and the number of values.
 struct UncompressedValues {
   double const * const data;

--- a/bindings/python/tersets/__init__.py
+++ b/bindings/python/tersets/__init__.py
@@ -86,8 +86,8 @@ class Method(Enum):
     PiecewiseLinearHistogram = 7
     ABCLinearApproximation = 8
     VisvalingamWhyatt = 9
-    BottomUp = 10
-    SlidingWindow = 11
+    SlidingWindow = 10
+    BottomUp = 11
 
 # Public Functions.
 def compress(values: List[float], method: Method, error_bound: float) -> bytes:

--- a/bindings/python/tests/test_c_method_enum.py
+++ b/bindings/python/tests/test_c_method_enum.py
@@ -1,0 +1,40 @@
+import pathlib
+import re
+import unittest
+
+class CMethodEnumMatchTest(unittest.TestCase):
+    def test_c_method_enum_matches_zig(self):
+        repo_root = pathlib.Path(__file__).resolve().parents[3]
+        c_file = repo_root / 'bindings' / 'c' / 'tersets.h'
+        c_content = c_file.read_text()
+        c_match = re.search(r"enum\s+Method\s*{([^}]*)}", c_content, re.MULTILINE)
+        self.assertIsNotNone(c_match, 'Could not find enum Method in tersets.h')
+        c_body = c_match.group(1)
+        c_methods = []
+        c_values = []
+        for line in c_body.splitlines():
+            line = line.strip().rstrip(',')
+            if not line:
+                continue
+            if '=' in line:
+                name, value = [part.strip() for part in line.split('=', 1)]
+                c_methods.append(name)
+                c_values.append(int(value, 0))
+            else:
+                c_methods.append(line)
+                c_values.append(None)
+
+        zig_file = repo_root / 'src' / 'tersets.zig'
+        zig_content = zig_file.read_text()
+        zig_match = re.search(r"pub const Method = enum\s*{([^}]*)}", zig_content, re.MULTILINE)
+        self.assertIsNotNone(zig_match, 'Could not find Method enum in tersets.zig')
+        zig_body = zig_match.group(1)
+        zig_methods = []
+        for line in zig_body.splitlines():
+            line = line.strip().rstrip(',')
+            if line:
+                zig_methods.append(line)
+
+        self.assertEqual(zig_methods, c_methods)
+        self.assertEqual(list(range(len(c_methods))), c_values)
+

--- a/bindings/python/tests/test_method_enum.py
+++ b/bindings/python/tests/test_method_enum.py
@@ -1,0 +1,23 @@
+import pathlib
+import re
+import unittest
+from tersets import Method
+
+class MethodEnumMatchTest(unittest.TestCase):
+    def test_python_method_enum_matches_zig(self):
+        repo_root = pathlib.Path(__file__).resolve().parents[3]
+        zig_file = repo_root / 'src' / 'tersets.zig'
+        content = zig_file.read_text()
+        match = re.search(r"pub const Method = enum\s*{([^}]*)}", content, re.MULTILINE)
+        self.assertIsNotNone(match, 'Could not find Method enum in tersets.zig')
+        body = match.group(1)
+        zig_methods = []
+        for line in body.splitlines():
+            line = line.strip().rstrip(',')
+            if line:
+                zig_methods.append(line)
+        python_methods = [member.name for member in Method]
+        self.assertEqual(zig_methods, python_methods)
+        for i, member in enumerate(Method):
+            self.assertEqual(i, member.value)
+


### PR DESCRIPTION
## Summary
- ensure Python Method enum matches Zig implementation
- correct Python Method enum ordering
- add unittest to verify enums stay synchronized
- add C binding Method enum and matching test
- update README C example to reference the enum

## Testing
- `zig build -Doptimize=Debug`
- `zig build -Doptimize=ReleaseFast`
- `zig build test -Doptimize=Debug`
- `zig build test -Doptimize=ReleaseFast`
- `clang -Weverything tersets.h`
- `gcc -Wall -Wextra tersets.h`
- `python3 -m unittest --verbose`

------
https://chatgpt.com/codex/tasks/task_e_6863a085dca48328ba634d2bed045e29