### PR TITLE
Move isWithinErrorBound function to `shared_functions.zig` 

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -271,7 +271,7 @@ When implementing a new method (e.g., `Method.MyNewMethod`), you should:
            tester.generateRandomValues,
            Method.MyNewMethod,
            0,
-           tersets.isWithinErrorBound,
+           shared_functions.isWithinErrorBound,
        );
     }
     ```

--- a/src/functional_approximation/abc_linear_approximation.zig
+++ b/src/functional_approximation/abc_linear_approximation.zig
@@ -321,7 +321,7 @@ test "abc compressor can always compress and decompress with zero error bound" {
         tester.generateFiniteRandomValues,
         Method.ABCLinearApproximation,
         0,
-        tersets.isWithinErrorBound,
+        shared_functions.isWithinErrorBound,
     );
 }
 
@@ -418,6 +418,6 @@ test "abc compressor compresses and decompresses constant signal" {
         uncompressed_values.items,
         Method.ABCLinearApproximation,
         error_bound,
-        tersets.isWithinErrorBound,
+        shared_functions.isWithinErrorBound,
     );
 }

--- a/src/functional_approximation/mix_piece.zig
+++ b/src/functional_approximation/mix_piece.zig
@@ -1101,7 +1101,7 @@ test "mix-piece can compress, decompress and merge many segments with non-zero e
         uncompressed_values.items,
         Method.MixPiece,
         error_bound,
-        tersets.isWithinErrorBound,
+        shared_functions.isWithinErrorBound,
     );
 }
 
@@ -1211,7 +1211,7 @@ test "mix-piece handles time series with trend" {
         uncompressed_values.items,
         Method.MixPiece,
         error_bound,
-        tersets.isWithinErrorBound,
+        shared_functions.isWithinErrorBound,
     );
 }
 
@@ -1244,7 +1244,7 @@ test "mix-piece handles cross-intercept grouping" {
         uncompressed_values.items,
         Method.MixPiece,
         error_bound,
-        tersets.isWithinErrorBound,
+        shared_functions.isWithinErrorBound,
     );
 }
 
@@ -1274,7 +1274,7 @@ test "mix-piece handles single point segments" {
         uncompressed_values.items,
         Method.MixPiece,
         error_bound,
-        tersets.isWithinErrorBound,
+        shared_functions.isWithinErrorBound,
     );
 }
 
@@ -1298,6 +1298,6 @@ test "mix-piece floor vs ceil quantization selection" {
         uncompressed_values.items,
         Method.MixPiece,
         error_bound,
-        tersets.isWithinErrorBound,
+        shared_functions.isWithinErrorBound,
     );
 }

--- a/src/functional_approximation/poor_mans_compression.zig
+++ b/src/functional_approximation/poor_mans_compression.zig
@@ -145,7 +145,7 @@ test "midrange can always compress and decompress with zero error bound" {
         tester.generateRandomValues,
         Method.PoorMansCompressionMidrange,
         0,
-        tersets.isWithinErrorBound,
+        shared_functions.isWithinErrorBound,
     );
 }
 
@@ -179,7 +179,7 @@ test "mean can always compress and decompress with zero error bound" {
         tester.generateRandomValues,
         Method.PoorMansCompressionMean,
         0,
-        tersets.isWithinErrorBound,
+        shared_functions.isWithinErrorBound,
     );
 }
 

--- a/src/functional_approximation/sim_piece.zig
+++ b/src/functional_approximation/sim_piece.zig
@@ -625,7 +625,7 @@ test "sim-piece can compress, decompress and merge many segments with positive e
         uncompressed_values.items,
         Method.SimPiece,
         error_bound,
-        tersets.isWithinErrorBound,
+        shared_functions.isWithinErrorBound,
     );
 }
 

--- a/src/functional_approximation/swing_slide_filter.zig
+++ b/src/functional_approximation/swing_slide_filter.zig
@@ -867,7 +867,7 @@ test "swing filter can always compress and decompress with zero error bound" {
         tester.generateFiniteRandomValues,
         Method.SwingFilter,
         0,
-        tersets.isWithinErrorBound,
+        shared_functions.isWithinErrorBound,
     );
 }
 
@@ -900,7 +900,7 @@ test "swing filter disconnected can always compress and decompress with zero err
         tester.generateFiniteRandomValues,
         Method.SwingFilterDisconnected,
         0,
-        tersets.isWithinErrorBound,
+        shared_functions.isWithinErrorBound,
     );
 }
 
@@ -934,7 +934,7 @@ test "slide filter can always compress and decompress with zero error bound" {
         tester.generateFiniteRandomValues,
         Method.SlideFilter,
         0,
-        tersets.isWithinErrorBound,
+        shared_functions.isWithinErrorBound,
     );
 }
 

--- a/src/histogram_representation/constant_linear_representation.zig
+++ b/src/histogram_representation/constant_linear_representation.zig
@@ -789,7 +789,7 @@ test "PWCH can compress and decompress with bounded values and expected maximum 
         uncompressed_values.items,
         tersets.Method.PiecewiseConstantHistogram,
         error_bound,
-        tersets.isWithinErrorBound,
+        shared_functions.isWithinErrorBound,
     );
 }
 
@@ -936,6 +936,6 @@ test "PWLH can compress and decompress with bounded values and expected maximum 
         uncompressed_values.items,
         tersets.Method.PiecewiseLinearHistogram,
         error_bound,
-        tersets.isWithinErrorBound,
+        shared_functions.isWithinErrorBound,
     );
 }

--- a/src/line_simplification/bottom_up.zig
+++ b/src/line_simplification/bottom_up.zig
@@ -372,7 +372,7 @@ test "bottom-up can compress and decompress with zero error bound" {
         uncompressed_values.items,
         Method.BottomUp,
         error_bound,
-        tersets.isWithinErrorBound,
+        shared_functions.isWithinErrorBound,
     );
 }
 

--- a/src/line_simplification/sliding_window.zig
+++ b/src/line_simplification/sliding_window.zig
@@ -193,7 +193,7 @@ test "sliding-window can compress and decompress bounded values with zero error 
         uncompressed_values.items,
         Method.SlidingWindow,
         error_bound,
-        tersets.isWithinErrorBound,
+        shared_functions.isWithinErrorBound,
     );
 }
 

--- a/src/line_simplification/visvalingam_whyatt.zig
+++ b/src/line_simplification/visvalingam_whyatt.zig
@@ -338,7 +338,7 @@ test "vw compress and decompress with zero error bound" {
     try compress(allocator, uncompressed_values.items, &compressed_values, error_bound);
     try decompress(compressed_values.items, &decompressed_values);
 
-    try std.testing.expect(tersets.isWithinErrorBound(
+    try std.testing.expect(shared_functions.isWithinErrorBound(
         uncompressed_values.items,
         decompressed_values.items,
         error_bound,

--- a/src/lossless_encoding/run_length_encoding.zig
+++ b/src/lossless_encoding/run_length_encoding.zig
@@ -132,6 +132,6 @@ test "run length encoding compresses repeated values" {
         uncompressed_values.items,
         Method.RunLengthEncoding,
         0,
-        tersets.isWithinErrorBound,
+        shared_functions.isWithinErrorBound,
     );
 }

--- a/src/quantization/bitpacked_quantization.zig
+++ b/src/quantization/bitpacked_quantization.zig
@@ -284,7 +284,7 @@ test "bitpacked quantization can compress and decompress bounded values at diffe
         uncompressed_values.items,
         Method.BitPackedQuantization,
         error_bound,
-        tersets.isWithinErrorBound,
+        shared_functions.isWithinErrorBound,
     );
 }
 
@@ -307,7 +307,7 @@ test "bitpacked quantization can compress and decompress with zero error bound a
         uncompressed_values.items,
         Method.BitPackedQuantization,
         error_bound,
-        tersets.isWithinErrorBound,
+        shared_functions.isWithinErrorBound,
     );
 }
 

--- a/src/tersets.zig
+++ b/src/tersets.zig
@@ -254,26 +254,6 @@ pub fn decompress(
     return decompressed_values;
 }
 
-/// Auxiliary function to validate of the decompressed time series is within the error bound of the
-/// uncompressed time series. The function returns true if all elements are within the error bound,
-/// false otherwise.
-pub fn isWithinErrorBound(
-    uncompressed_values: []const f64,
-    decompressed_values: []const f64,
-    error_bound: f32,
-) bool {
-    if (uncompressed_values.len != decompressed_values.len) {
-        return false;
-    }
-
-    for (0..uncompressed_values.len) |index| {
-        const uncompressed_value = uncompressed_values[index];
-        const decompressed_value = decompressed_values[index];
-        if (@abs(uncompressed_value - decompressed_value) > error_bound) return false;
-    }
-    return true;
-}
-
 /// Get the maximum index of the available methods in TerseTS.
 pub fn getMaxMethodIndex() usize {
     const method_info = @typeInfo(Method).@"enum";

--- a/src/utilities/shared_functions.zig
+++ b/src/utilities/shared_functions.zig
@@ -119,3 +119,23 @@ pub fn computeMaxAbsoluteError(uncompressed_values: []const f64, seg_start: usiz
     // Return max abs.
     return linf;
 }
+
+/// Auxiliary function to validate of the decompressed time series is within the error bound of the
+/// uncompressed time series. The function returns true if all elements are within the error bound,
+/// false otherwise.
+pub fn isWithinErrorBound(
+    uncompressed_values: []const f64,
+    decompressed_values: []const f64,
+    error_bound: f32,
+) bool {
+    if (uncompressed_values.len != decompressed_values.len) {
+        return false;
+    }
+
+    for (0..uncompressed_values.len) |index| {
+        const uncompressed_value = uncompressed_values[index];
+        const decompressed_value = decompressed_values[index];
+        if (@abs(uncompressed_value - decompressed_value) > error_bound) return false;
+    }
+    return true;
+}


### PR DESCRIPTION
### Summary

This PR moves the `isWithinErrorBound` function from `src/tersets.zig` file to the file `src/utilities/shared_functions.zig` for consistency and better structuring. 

### Files Added/Modified
- Almost all were modified to switch from `tersets.isWithinErrorBound` to `shared_functions.isWithinErrorBound`.
 

### Testing

- No new tests added.

