### PR TITLE
Clear Zig’s local cache on runners

### DIFF
--- a/.github/workflows/zig-build-lint-and-test-on-pr-and-push.yml
+++ b/.github/workflows/zig-build-lint-and-test-on-pr-and-push.yml
@@ -36,7 +36,11 @@ jobs:
     - uses: mlugg/setup-zig@v2
       with:
         version: 0.14.0  # Use a stable Zig version
-
+    - name: Clear Zig Cache (Windows only)
+      if: runner.os == 'Windows'
+      run: |
+        Remove-Item -Recurse -Force "$env:LOCALAPPDATA\zig" -ErrorAction SilentlyContinue
+      shell: pwsh
     - name: Zig Build Debug
       run: zig build -Doptimize=Debug
     - name: Zig Build ReleaseFast

--- a/.github/workflows/zig-build-lint-and-test-on-pr-and-push.yml
+++ b/.github/workflows/zig-build-lint-and-test-on-pr-and-push.yml
@@ -36,10 +36,8 @@ jobs:
     - uses: mlugg/setup-zig@v2
       with:
         version: 0.14.0  # Use a stable Zig version
-    - name: Clear Zig Cache (Windows only)
-      if: runner.os == 'Windows'
-      run: |
-        Remove-Item -Recurse -Force "$env:LOCALAPPDATA\zig" -ErrorAction SilentlyContinue
+    - name: Clear Zig Cache 
+      run: Remove-Item -Recurse -Force "$env:LOCALAPPDATA\zig" -ErrorAction SilentlyContinue
       shell: pwsh
     - name: Zig Build Debug
       run: zig build -Doptimize=Debug


### PR DESCRIPTION
### Summary

In a previous PR, I got the job failed with the error: error: failed to spawn build runner C:\Users\runneradmin\AppData\Local\zig\o\7e48997dfe81227c2fec25ad9d476202\build.exe: FileNotFound
This happens when running zig build commands in the workflow. The most likely cause is that Zig is unable to find or generate build.exe in the cache directory, possibly due to a corrupted Zig cache or a previous failed build..

### Solution:

Add a step before the Zig build steps to clear Zig’s local cache on Windows runners. You can do this by inserting the following step in your workflow before running any zig build command:

- name: Clear Zig Cache 
  run: Remove-Item -Recurse -Force "$env:LOCALAPPDATA\zig" -ErrorAction SilentlyContinue
  shell: pwsh

