### PR TITLE
Serf-Qt, Serf-Xor implementation

### DIFF
--- a/bindings/c/tersets.h
+++ b/bindings/c/tersets.h
@@ -24,6 +24,8 @@ enum Method {
   BitPackedQuantization         = 13,
   RunLengthEncoding             = 14,
   NonLinearApproximation        = 15,
+  Serf_Qt                       = 16,
+  Serf_Xor                      = 17
 };
 
 // Read-only view of input data (the library will not modify it).

--- a/bindings/python/tersets/__init__.py
+++ b/bindings/python/tersets/__init__.py
@@ -103,6 +103,8 @@ class Method(Enum):
     BitPackedQuantization = 13
     RunLengthEncoding = 14
     NonLinearApproximation = 15
+    SerfQt = 16
+    SerfXor = 17
 
 # Public API. 
 def compress(values, method, error_bound: float) -> bytes:

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,14 @@
+rec {
+    pkgs = import <nixpkgs> {};
+    tersets = pkgs.stdenv.mkDerivation rec {
+        stdenv = pkgs.stdenv;
+        pkg-config = pkgs.pkg-config;
+        binutils = pkgs.binutils;
+        zig = pkgs.zig_0_14;
+        buildInputs = [ stdenv pkg-config binutils zig ];
+        name = "TerseTS";
+        description = "collection of lossy timeseries compression algorithms";
+        # builder = ./nix-builder.sh;
+        src = ./.;
+    };
+}

--- a/src/capi.zig
+++ b/src/capi.zig
@@ -161,6 +161,12 @@ test "method enum must match method constants" {
     try testing.expectEqual(@intFromEnum(tersets.Method.VisvalingamWhyatt), 9);
     try testing.expectEqual(@intFromEnum(tersets.Method.SlidingWindow), 10);
     try testing.expectEqual(@intFromEnum(tersets.Method.BottomUp), 11);
+    try testing.expectEqual(@intFromEnum(tersets.Method.MixPiece), 12);
+    try testing.expectEqual(@intFromEnum(tersets.Method.BitPackedQuantization), 13);
+    try testing.expectEqual(@intFromEnum(tersets.Method.RunLengthEncoding), 14);
+    try testing.expectEqual(@intFromEnum(tersets.Method.NonLinearApproximation), 15);
+    try testing.expectEqual(@intFromEnum(tersets.Method.SerfQt), 16);
+    try testing.expectEqual(@intFromEnum(tersets.Method.SerfXor), 17);
 }
 
 test "error for unknown compression method" {

--- a/src/serf/serf_qt.zig
+++ b/src/serf/serf_qt.zig
@@ -1,0 +1,255 @@
+// Copyright 2025 TerseTS Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const std = @import("std");
+const mem = std.mem;
+const testing = std.testing;
+const time = std.time;
+
+const Encoding = @import("../utilities/encoding.zig");
+const tersets = @import("../tersets.zig");
+const Tester = @import("../tester.zig");
+
+const ArrayList = std.ArrayList;
+const Random = std.Random;
+
+const Error = tersets.Error;
+
+pub fn compress(values: []const f64, out: *ArrayList(u8), error_bound: f32) Error!void {
+    const output_size = try compressSerfQtResultSize(f64, values, @floatCast(error_bound));
+    try out.ensureTotalCapacity(output_size + @sizeOf(f32));
+    try out.appendNTimes(0, output_size + @sizeOf(f32));
+    // write error bound to start of stream
+    // NOTE: zig appears not to support any of the more straightforward ways of doing this
+    const err_bound_u32 = @as(u32, @bitCast(error_bound));
+    out.items[0] = @as(u8, @truncate(err_bound_u32 >> 24));
+    out.items[1] = @as(u8, @truncate(err_bound_u32 >> 16));
+    out.items[2] = @as(u8, @truncate(err_bound_u32 >> 8));
+    out.items[3] = @as(u8, @truncate(err_bound_u32));
+    try compressSerfQtUnmanaged(f64, values, @floatCast(error_bound), out.items[@sizeOf(f32)..out.items.len]);
+}
+
+pub fn decompress(stream_raw: []const u8, out: *ArrayList(f64)) Error!void {
+    // extract error bound as f32 from start of stream
+    // NOTE: zig appears not to support any of the more straightforward ways of doing this
+    const err_bound_u32 =
+        (@as(u32, stream_raw[0]) << 24)
+        | (@as(u32, stream_raw[1]) << 16)
+        | (@as(u32, stream_raw[2]) << 8)
+        | @as(u32, stream_raw[3]);
+    const error_bound = @as(f32, @bitCast(err_bound_u32));
+
+    const stream = stream_raw[@sizeOf(f32)..stream_raw.len];
+
+    const out_elems = decompressSerfQtElemCount(stream);
+    try out.ensureTotalCapacity(out_elems);
+    try out.appendNTimes(0, out_elems);
+
+    decompressSerfQtUnmanaged(
+        f64,
+        stream,
+        error_bound,
+        out.items
+    );
+}
+
+fn errorBoundToQuantum(error_bound: f64) f64 {
+    // using error_bound * 2 can and does cause occasional issues with staying
+    // within error bound
+    return error_bound * 1.9;
+}
+
+fn compressSerfQtResultSize(comptime FP_TYPE: type, values: []const FP_TYPE, error_bound: f64) Error!u64 {
+    const quantum = errorBoundToQuantum(error_bound);
+    var predicted: f64 = 0.0;
+    var result: u64 = 0;
+
+    for (values) |v| {
+        const quantized_delta = try quantize(v, predicted, quantum);
+        predicted = dequantize(quantized_delta, predicted, quantum);
+        const zigzagd = Encoding.zigzagEncode(quantized_delta);
+        const eg_res = Encoding.gammaEncodeSingle(zigzagd + 1);
+        result += 1 + (eg_res.leading_zeros * 2);
+    }
+
+    // convert to bytes
+    result += 7;
+    result /= 8;
+    return result;
+}
+
+fn compressSerfQtUnmanaged(comptime FP_TYPE: type, values: []const FP_TYPE, error_bound: f64, out: []u8) Error!void {
+    const quantum = errorBoundToQuantum(error_bound);
+    var predicted: f64 = 0.0;
+    var gamma_index: u64 = 0;
+
+    for (values) |v| {
+        const quantized_delta = try quantize(v, predicted, quantum);
+        predicted = dequantize(quantized_delta, predicted, quantum);
+        const zigzagd = Encoding.zigzagEncode(quantized_delta);
+        Encoding.gammaEncodeIter(zigzagd + 1, out, &gamma_index);
+    }
+}
+
+
+pub fn decompressSerfQtElemCount(stream: []const u8) u64 {
+    return Encoding.gammaDecodeElemCount(stream);
+}
+
+pub fn decompressSerfQtUnmanaged(comptime FP_TYPE: type, stream: []const u8, error_bound: f64, values: []FP_TYPE) void {
+    const quantum = errorBoundToQuantum(error_bound);
+
+    var predicted: f64 = 0.0;
+    var degamma_idx: u64 = 0;
+
+    const num_bits = 8 * stream.len;
+    var i: u64 = 0;
+    while ((i < values.len) and (degamma_idx < num_bits)) {
+        if (Encoding.onlyZerosFollow(stream, degamma_idx)) {
+            break;
+        }
+        const degamma_v = Encoding.gammaDecodeIter(stream, &degamma_idx);
+        const dezigzagd = Encoding.zigzagDecode(degamma_v - 1);
+        const v = dequantize(dezigzagd, predicted, quantum);
+        predicted = v;
+        values[i] = @as(FP_TYPE, @floatCast(v));
+
+        i += 1;
+    }
+}
+
+const I64_MAX = std.math.maxInt(i64);
+const I64_MIN = std.math.minInt(i64);
+
+fn quantize(value: f64, base: f64, quantum: f64) Error!i64 {
+    const delta = value - base;
+    const fres = @floor((delta / quantum) + 0.5);
+
+    if ((fres < @as(f64, @floatFromInt(I64_MAX))) and (fres > @as(f64, @floatFromInt(I64_MIN)))) {
+        return @intFromFloat(fres);
+    }
+    return error.UnsupportedInput;
+}
+
+fn dequantize(value: i64, base: f64, quantum: f64) f64 {
+    const delta = @as(f64, @floatFromInt(value)) * quantum;
+    return delta + base;
+}
+
+// ~1M iterations; if the compiler isn't horrid, this should run quick but still give us some usable indication
+test "quantization -> dequantization is accurate when using quantum = error_bound * 1.9 with error bounds between 0.0001 and 0.1" {
+    // NOTE: using time to seed a PRNG - while common practice - makes for a somewhat poorly seeded PRNG
+    // TODO: use /dev/urandom instead
+    var prng = Random.DefaultPrng.init(@bitCast(time.milliTimestamp()));
+    const random = prng.random();
+    for (1..1000) |err_b_int| {
+        const error_bound = 0.0001 * @as(f64, @floatFromInt(err_b_int));
+        const quantum = error_bound * 1.9;
+
+        const lower_bound = -1000.0;
+        const upper_bound = 1000.0;
+
+        for (0..1000) |_| {
+            const num = Tester.generateBoundedRandomValue(f64, lower_bound, upper_bound, random);
+            const quantized = try quantize(num, 0, quantum);
+            const dequantized = dequantize(quantized, 0, quantum);
+
+            try testing.expectApproxEqAbs(num, dequantized, error_bound);
+        }
+    }
+}
+
+test "quantization fails if input delta is unrepresentable as i64" {
+    try testing.expectError(error.UnsupportedInput, quantize(@as(f64, @floatFromInt(I64_MAX)) + 10000.0, 0, 1.0));
+    try testing.expectError(error.UnsupportedInput, quantize(@as(f64, @floatFromInt(I64_MIN)) - 10000.0, 0, 1.0));
+}
+
+
+test "serf-qt fails when delta can't be quantized using quantization.quantize" {
+    const v = [1]f64 { 8 * @as(f64, @floatFromInt(@as(u64, 1) << 63)) };
+    var buffer: [128]u8 = .{
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    };
+    try testing.expectError(error.UnsupportedInput, compressSerfQtUnmanaged(f64, &v, 1.0, &buffer));
+}
+
+test "serf-qt can compress and decompress constant data" {
+    const input: [128]f64 = .{
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    };
+    var buffer = ArrayList(u8).init(testing.allocator);
+    defer buffer.deinit();
+
+    // should compress down to 128 bits
+    const count = try compressSerfQtResultSize(f64, &input, 1.0);
+    try testing.expectEqual(count, 128 / 8);
+
+    try compress(&input, &buffer, 1.0);
+
+    var out = ArrayList(f64).init(testing.allocator);
+    defer out.deinit();
+
+    try decompress(buffer.items, &out);
+
+    for (input, out.items) |i, o| {
+        try testing.expectEqual(i, o);
+    }
+}
+
+test "serf-qt can compress and decompress random quantizable data" {
+    var prng = Random.DefaultPrng.init(@bitCast(std.time.milliTimestamp()));
+    const random = prng.random();
+    for (1..1000) |inputs_length| {
+        const error_bound = Tester.generateBoundedRandomValue(f64, 0.00001, 30.0, random);
+
+        var inputs = try std.ArrayList(f64).initCapacity(testing.allocator, inputs_length);
+        defer inputs.deinit();
+        var prev: f64 = 0.0;
+        for (0..inputs_length) |_| {
+            const val = Tester.generateBoundedRandomValue(f64, prev - (error_bound * 10000), prev + (error_bound * 10000), random);
+            try inputs.append(val);
+            prev = val;
+        }
+
+        var outputs = std.ArrayList(u8).init(testing.allocator);
+        defer outputs.deinit();
+
+        try compress(inputs.items, &outputs, @floatCast(error_bound));
+
+        var decompressed = std.ArrayList(f64).init(testing.allocator);
+        defer decompressed.deinit();
+
+        try decompress(outputs.items, &decompressed);
+
+        for (inputs.items, decompressed.items) |expected, actual| {
+            try testing.expectApproxEqAbs(expected, actual, error_bound);
+        }
+    }
+}
+
+// TODO: more tests (one for each dataset, with some randomization around precision)

--- a/src/serf/serf_xor.zig
+++ b/src/serf/serf_xor.zig
@@ -1,0 +1,935 @@
+// Copyright 2025 TerseTS Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const std = @import("std");
+const mem = std.mem;
+const testing = std.testing;
+const ArrayList = std.ArrayList;
+const assert = std.debug.assert;
+
+const shared_structs = @import("../utilities/shared_structs.zig");
+const BitStream = shared_structs.BitStream;
+
+const Tester = @import("../tester.zig");
+
+const U32_MAX: u32 = 0xFFFF_FFFF;
+
+pub fn compress(values: []const f64, out: *ArrayList(u8), error_bound: f32) !void {
+    // ensure there's at least the minimum amount of space we need
+    try out.ensureTotalCapacity((values.len / 2) + (2 * @sizeOf(u64)));
+
+    const adjust_digit = adjustDigitFromInput(values);
+    try writeU64ToArrayList(out, adjust_digit);
+
+    // TODO: make window size adjustable or just use the default that is being used in the serf paper
+    const window_size = default_window_size;
+    try writeU64ToArrayList(out, window_size);
+
+    const max_diff = maxDiffFromErrorBound(error_bound);
+
+    var state = try SerfXORCompress.start(max_diff, adjust_digit, window_size, out);
+    state.buffer.fill = 2 * @bitSizeOf(u64);
+    for (values, 0..) |v, v_idx| {
+        std.log.warn("compress {} (idx {})", .{v, v_idx});
+        try state.compress(v);
+    }
+    out.* = try state.close();
+}
+
+pub fn decompress(input: []const u8, out: *ArrayList(f64)) !void {
+    // read adjust digit from input
+    const adjust_digit = readU64FromArray(input);
+    const window_size = readU64FromArray(input[@sizeOf(u64)..input.len]);
+
+    var state = SerfXORDecompress.start(adjust_digit, window_size, input[(2 * @sizeOf(u64))..input.len]);
+    var value_counter: usize = 0;
+    while (state.haveNextValue()) {
+        const v = state.readNextValue();
+        std.log.warn("value {} counter {}", .{ v, value_counter });
+        try out.append(v);
+        value_counter += 1;
+    }
+}
+
+pub const PostOfficeSolver = struct {
+    pub const PostOfficeResult = struct {
+        office_positions: SmallUnmanagedArrayList,
+        total_app_cost: u32,
+
+        pub fn init() PostOfficeResult {
+            return PostOfficeResult {
+                .office_positions = SmallUnmanagedArrayList.init(),
+                .total_app_cost = 0,
+            };
+        }
+    };
+
+    const position_length_2bits = [65]u32 {
+     0, 0, 1, 2, 2, 3, 3, 3, 3,
+        4, 4, 4, 4, 4, 4, 4, 4,
+        5, 5, 5, 5, 5, 5, 5, 5,
+        5, 5, 5, 5, 5, 5, 5, 5,
+        6, 6, 6, 6, 6, 6, 6, 6,
+        6, 6, 6, 6, 6, 6, 6, 6,
+        6, 6, 6, 6, 6, 6, 6, 6,
+        6, 6, 6, 6, 6, 6, 6, 6,
+    };
+
+    pub fn initRoundAndRepresentation(distribution: *[64]u32, representation: *[64]u32, round: *[64]u32) SmallUnmanagedArrayList {
+        var pre_non_zeros_count = [64]u32 {
+            0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0,
+        };
+        var post_non_zeros_count = [64]u32 {
+            0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0,
+        };
+        const total_count_and_non_zeros_counts = calTotalCountAndNonZerosCounts(distribution, &pre_non_zeros_count, &post_non_zeros_count);
+
+        const max_z = @min(position_length_2bits[total_count_and_non_zeros_counts[1]], 5);
+        var total_cost: u32 = U32_MAX;
+
+        var positions = SmallUnmanagedArrayList.init();
+        var present_cost: u32 = 0;
+        var por = PostOfficeResult.init();
+        for (0..(max_z + 1)) |z| {
+            present_cost = total_count_and_non_zeros_counts[0] * @as(u32, @truncate(z));
+            if (present_cost >= total_cost) {
+                break;
+            }
+
+            const num = pow2z(@truncate(z));
+            por = buildPostOffice(distribution, num, total_count_and_non_zeros_counts[1], &pre_non_zeros_count, &post_non_zeros_count);
+            const temp_total_cost = por.total_app_cost + present_cost;
+            if (temp_total_cost < total_cost) {
+                total_cost = temp_total_cost;
+                positions = por.office_positions;
+            }
+        }
+
+        representation[0] = 0;
+        round[0] = 0;
+        var i: u32 = 1;
+        for (1..distribution.len) |j| {
+            const magic_code = @as(u32, @intFromBool((i < positions.len) and (j == positions.items[i])));
+            representation[j] = representation[j - 1] + magic_code;
+            // original implementation suggests a cmov is desired here
+            if (magic_code != 0) {
+                round[j] = @truncate(j);
+            } else {
+                round[j] = round[j - 1];
+            }
+            i += magic_code;
+
+            // equivalent code to the above:
+            // if (i < positions.len && j == positions[i]) {
+            //     representation[j] = representation[j - 1] + 1;
+            //     round[j] = j;
+            //     i += 1;
+            // } else {
+            //     representation[j] = representation[j - 1];
+            //     round[j] = round[j - 1];
+            // }
+        }
+
+        return positions;
+    }
+
+    pub fn writePositions(positions: SmallUnmanagedArrayList, out: *BitStream) !u64 {
+        var bit_count: u64 = 5;
+        try out.write(positions.len, 5);
+        for (0..positions.len) |i| {
+            const pos = positions.items[i];
+            try out.write(pos, 6);
+            bit_count += 6;
+        }
+        return bit_count;
+    }
+
+    pub fn pow2z(i: u32) u32 {
+        std.debug.assert(i < 6);
+        return @as(u32, 1) << @truncate(i);
+    }
+
+    pub fn calTotalCountAndNonZerosCounts(arr: *[64]u32, out_pre_non_zeros_count: *[64]u32, out_post_non_zeros_count: *[64]u32) [2]u32 {
+        std.debug.assert(arr.len == out_pre_non_zeros_count.len);
+        std.debug.assert(arr.len == out_post_non_zeros_count.len);
+
+        var non_zeros_count = arr.len;
+        var total_count = arr[0];
+        out_pre_non_zeros_count[0] = 1; // initial value
+        for (1..arr.len) |i| {
+            total_count += arr[i];
+            // less comprehensible but faster code
+            const magic_code = arr[i] == 0;
+            non_zeros_count -= @as(usize, @intFromBool(magic_code));
+            out_pre_non_zeros_count[i] = out_pre_non_zeros_count[i - 1] + @as(u32, @intFromBool(!magic_code));
+
+            // equivalent code follows
+            // if (arr[i] == 0) {
+            //     non_zeros_count -= 1;
+            //     out_pre_non_zeros_count[i] = out_pre_non_zeros_count[i - 1];
+            // } else {
+            //     out_pre_non_zeros_count[i] = out_pre_non_zeros_count[i - 1] + 1;
+            // }
+        }
+        for (0..arr.len) |i| {
+            out_post_non_zeros_count[i] = @as(u32, @truncate(non_zeros_count)) - out_pre_non_zeros_count[i];
+        }
+        return [2]u32 { total_count, @truncate(non_zeros_count) };
+    }
+
+    pub fn buildPostOffice(arr: *[64]u32, original_num: u32, non_zeros_count: u32, pre_non_zeros_count: []u32, post_non_zeros_count: []u32) PostOfficeResult {
+        const num = @min(original_num, non_zeros_count);
+
+        var dp = [64]SmallUnmanagedArrayList {
+            SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num),
+            SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num),
+            SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num),
+            SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num),
+            SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num),
+            SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num),
+            SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num),
+            SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num),
+        };
+        var pre = [64]SmallUnmanagedArrayList {
+            SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num),
+            SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num),
+            SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num),
+            SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num),
+            SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num),
+            SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num),
+            SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num),
+            SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num), SmallUnmanagedArrayList.initLen(num),
+        };
+
+        dp[0].items[0] = 0;
+        pre[0].items[0] = 0; // WAS: -1
+
+        for (1..arr.len) |iu| {
+            const i = @as(u32, @truncate(iu));
+            if (arr[i] == 0) {
+                continue;
+            }
+            for (@max(1, @as(i64, @intCast(num)) + @as(i64, @intCast(i)) - @as(i64, @intCast(arr.len)))..@min(i + 1, num)) |ju| {
+                const j = @as(u32, @truncate(ju));
+                if ((i > 1) and (j == 1)) {
+                    dp[i].items[j] = 0;
+                    for (1..i) |ku| {
+                        const k = @as(u32, @truncate(ku));
+                        dp[i].items[j] += arr[k] * k;
+                    }
+                    pre[i].items[j] = 0;
+                } else {
+                    if ((pre_non_zeros_count[i] < j + 1) or (post_non_zeros_count[i] < num - 1 - j)) {
+                        continue;
+                    }
+                    var app_cost: u32 = 0xFFFF_FFFF;
+                    var pre_k: u32 = 0;
+                    for ((j - 1)..i) |ku| {
+                        const k = @as(u32, @truncate(ku));
+                        if ((arr[k] == 0 and k > 0) or (pre_non_zeros_count[k] < j) or (post_non_zeros_count[k] < num - j)) {
+                            continue;
+                        }
+                        var sum = dp[k].items[j - 1];
+                        for ((k + 1)..i) |pu| {
+                            const p = @as(u32, @truncate(pu));
+                            sum += arr[p] * (p - k);
+                        }
+                        if (app_cost > sum) {
+                            app_cost = sum;
+                            pre_k = k;
+                            if (sum == 0) {
+                                break;
+                            }
+                        }
+                    }
+                    if (app_cost != 0xFFFF_FFFF) {
+                        dp[i].items[j] = app_cost;
+                        pre[i].items[j] = pre_k;
+                    }
+                }
+            }
+        }
+        var temp_total_app_cost: u32 = 0xFFFF_FFFF;
+        var temp_best_last: u32 = 0x7FFF_FFFF;
+        for ((num - 1)..arr.len) |iu| {
+            const i = @as(u32, @truncate(iu));
+            if ((num - 1 == 0) and (i > 0)) {
+                break;
+            }
+            if (((arr[i] == 0) and (i > 0)) or (pre_non_zeros_count[i] < num)) {
+                continue;
+            }
+            var sum = dp[i].items[num - 1];
+            for ((i + 1)..arr.len) |ju| {
+                const j = @as(u32, @truncate(ju));
+                sum += arr[j] * (j - 1);
+            }
+            if (temp_total_app_cost > sum) {
+                temp_total_app_cost = sum;
+                temp_best_last = i;
+            }
+        }
+
+        var office_positions = SmallUnmanagedArrayList.initLen(num);
+        var i: u32 = 1;
+        while (temp_best_last != -1 and i <= num) {
+            office_positions.items[num - i] = temp_best_last;
+            temp_best_last = pre[temp_best_last].items[num - i];
+            i += 1;
+        }
+
+        if (original_num > non_zeros_count) {
+            var modifying_office_positions = SmallUnmanagedArrayList.initLen(original_num);
+            var j: u32 = 0;
+            var k: u32 = 0;
+            while ((j < original_num) and (k < num)) {
+                if ((j - k < original_num - num) and (j < office_positions.items[k])) {
+                    modifying_office_positions.items[j] = j;
+                    j += 1;
+                } else {
+                    modifying_office_positions.items[j] = office_positions.items[k];
+                    j += 1;
+                    k += 1;
+                }
+            }
+            office_positions = modifying_office_positions;
+        }
+
+        return PostOfficeResult {
+            .office_positions = office_positions,
+            .total_app_cost = temp_total_app_cost,
+        };
+    }
+};
+
+pub const SerfXORCompress = struct {
+    buffer: BitStream,
+    max_diff: f64,
+    adjust_digit: u64,
+    
+    stored_val: u64,
+    
+    leading_representation: [64]u32,
+    leading_round: [64]u32,
+    trailing_representation: [64]u32,
+    trailing_round: [64]u32,
+    leading_bits_per_value: u32,
+    trailing_bits_per_value: u32,
+    lead_distribution: [64]u32,
+    trail_distribution: [64]u32,
+    stored_leading_zeros: u32,
+    stored_trailing_zeros: u32,
+    
+    window_size: u32,
+    number_of_values_this_window: u32,
+    compressed_size_this_window: u64,
+    compression_ratio_last_window: f64,
+    
+    pub fn start(max_diff: f64, adjust_digit: u64, window_size: u32, out: *ArrayList(u8)) !SerfXORCompress {
+        const buffer = BitStream.makeFromArrayList(out, 0);
+        return SerfXORCompress {
+            .buffer = buffer,
+            .max_diff = max_diff,
+            .adjust_digit = adjust_digit,
+            
+            .stored_val = @as(f64, 2.0),
+            .leading_representation = [64]u32 {
+                0, 0, 0, 0, 0, 0, 0, 0,
+                1, 1, 1, 1, 2, 2, 2, 2,
+                3, 3, 4, 4, 5, 5, 6, 6,
+                7, 7, 7, 7, 7, 7, 7, 7,
+                7, 7, 7, 7, 7, 7, 7, 7,
+                7, 7, 7, 7, 7, 7, 7, 7,
+                7, 7, 7, 7, 7, 7, 7, 7,
+                7, 7, 7, 7, 7, 7, 7, 7,
+            },
+            .leading_round = [64]u32 {
+                0, 0, 0, 0, 0, 0, 0, 0,
+                8, 8, 8, 8, 12, 12, 12, 12,
+                16, 16, 18, 18, 20, 20, 22, 22,
+                24, 24, 24, 24, 24, 24, 24, 24,
+                24, 24, 24, 24, 24, 24, 24, 24,
+                24, 24, 24, 24, 24, 24, 24, 24,
+                24, 24, 24, 24, 24, 24, 24, 24,
+                24, 24, 24, 24, 24, 24, 24, 24,
+            },
+            .trailing_representation = [64]u32 {
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 1, 1,
+                1, 1, 1, 1, 2, 2, 2, 2,
+                3, 3, 3, 3, 4, 4, 4, 4,
+                5, 5, 6, 6, 6, 6, 7, 7,
+                7, 7, 7, 7, 7, 7, 7, 7,
+                7, 7, 7, 7, 7, 7, 7, 7,
+            },
+            .trailing_round = [64]u32 {
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 22, 22,
+                22, 22, 22, 22, 28, 28, 28, 28,
+                32, 32, 32, 32, 36, 36, 36, 36,
+                40, 40, 42, 42, 42, 42, 46, 46,
+                46, 46, 46, 46, 46, 46, 46, 46,
+                46, 46, 46, 46, 46, 46, 46, 46,
+            },
+            .leading_bits_per_value = 3,
+            .trailing_bits_per_value = 3,
+            .lead_distribution = [64]u32 {
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+            },
+            .trail_distribution = [64]u32 {
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+            },
+            .stored_leading_zeros = 0xFFFF_FFFF,
+            .stored_trailing_zeros = 0xFFFF_FFFF,
+            .window_size = window_size,
+            .number_of_values_this_window = 0,
+            .compressed_size_this_window = 0,
+            .compression_ratio_last_window = 0,
+        };
+    }
+    
+    // NetSerfXORCompressor::Compress()
+    pub fn compress(state: *SerfXORCompress, v: f64) !void {
+        var this_val: u64 = state.stored_val;
+        if (@abs(@as(f64, @bitCast(state.stored_val)) - @as(f64, @floatFromInt(state.adjust_digit)) - v) > state.max_diff) {
+            // much like the original implementation, we ignore any sorts of special cases that might occur here
+            const adjust_value = v + @as(f64, @floatFromInt(state.adjust_digit));
+            this_val = state.findAppLong(adjust_value - state.max_diff, adjust_value + state.max_diff, v);
+        }
+        try state.addValue(this_val);
+        state.stored_val = this_val;
+    }
+    
+    pub fn close(state: *SerfXORCompress) !ArrayList(u8) {
+        // std.math.nan() produces a quiet NaN
+        state.compressed_size_this_window += try state.compressValueInternal(@as(u64, @bitCast(std.math.nan(f64))));
+        
+        try state.updatePositionsIfNeeded();
+
+        return state.buffer.buffer.toManaged(state.buffer.allocator);
+    }
+    
+    pub fn delete(state: *SerfXORCompress) void {
+        state.buffer.destroy();
+        mem.zero(state);
+    }
+    
+    pub fn addValue(state: *SerfXORCompress, v: u64) !void {
+        // NOTE: transmission header shenanigans removed
+        if (state.number_of_values_this_window >= state.window_size) {
+            try state.updatePositionsIfNeeded();
+        }
+        state.compressed_size_this_window += try state.compressValueInternal(v);
+        state.number_of_values_this_window += 1;
+    }
+
+    pub fn updatePositionsIfNeeded(state: *SerfXORCompress) !void {
+        const compression_ratio_this_window = @as(f64, @floatFromInt(state.buffer.fill)) / (@as(f64, @floatFromInt(state.number_of_values_this_window)) * 64);
+        if (state.compression_ratio_last_window < compression_ratio_this_window) {
+            // update positions
+
+            const lead_positions = PostOfficeSolver.initRoundAndRepresentation(&state.lead_distribution, &state.leading_representation, &state.leading_round);
+            //const leading_bits_per_value = PostOfficeSolver.position_length_2bits[lead_positions.len];
+            const trail_positions = PostOfficeSolver.initRoundAndRepresentation(&state.trail_distribution, &state.trailing_representation, &state.trailing_round);
+            //const trailing_bits_per_value = PostOfficeSolver.position_length_2bits[trail_positions.len];
+
+            try state.buffer.writeBit(1);
+
+            _ = try PostOfficeSolver.writePositions(lead_positions, &state.buffer);
+            _ = try PostOfficeSolver.writePositions(trail_positions, &state.buffer);
+        } else {
+            try state.buffer.writeBit(0);
+        }
+        state.compression_ratio_last_window = compression_ratio_this_window;
+        state.compressed_size_this_window = 0;
+        state.number_of_values_this_window = 0;
+        state.lead_distribution = [64]u32 {
+            0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0,
+        };
+        state.trail_distribution = state.lead_distribution;
+    }
+    
+    pub fn compressValueInternal(state: *SerfXORCompress, value: u64) !u64 {
+        const starting_fill = state.buffer.fill;
+        const xor_result = state.stored_val ^ value;
+        if (xor_result == 0) {
+            // case 01
+            try state.buffer.writeBit(0);
+            try state.buffer.writeBit(1);
+            return state.buffer.fill - starting_fill;
+        }
+        
+        const leading_count = @clz(xor_result);
+        const trailing_count = @ctz(xor_result);
+        const leading_zeros = state.leading_round[leading_count];
+        const trailing_zeros = state.trailing_round[trailing_count];
+        state.lead_distribution[leading_count] += 1;
+        state.trail_distribution[trailing_count] += 1;
+        
+        if ((leading_zeros >= state.stored_leading_zeros)
+            and (trailing_zeros >= state.stored_trailing_zeros)
+            and ((leading_zeros - state.stored_leading_zeros) + (trailing_zeros - state.stored_trailing_zeros)
+                < (1 + state.leading_bits_per_value + state.trailing_bits_per_value))) {
+            // case 1
+            const center_bits = 64 - state.stored_leading_zeros - state.stored_trailing_zeros;
+            if (1 + center_bits > 64) {
+                try state.buffer.writeBit(1);
+                try state.buffer.write(xor_result >> @truncate(state.stored_trailing_zeros), @truncate(center_bits));
+            } else {
+                try state.buffer.write((@as(u64, 1) << @truncate(center_bits)) | (xor_result >> @truncate(state.stored_trailing_zeros)), @truncate(1 + center_bits));
+            }
+            return state.buffer.fill - starting_fill;
+        }
+        
+        // case 00
+        state.stored_leading_zeros = leading_zeros;
+        state.stored_trailing_zeros = trailing_zeros;
+        const center_bits = 64 - leading_zeros - trailing_zeros;
+        const len = 2 + state.leading_bits_per_value + state.trailing_bits_per_value + center_bits;
+        if (len > 64) {
+            var v = state.leading_representation[leading_zeros] << @truncate(state.trailing_bits_per_value);
+            v |= state.trailing_representation[trailing_zeros];
+            try state.buffer.write(v, @truncate(len - center_bits));
+            try state.buffer.write(xor_result >> @truncate(trailing_zeros), @truncate(center_bits));
+        } else {
+            var v = @as(u64, @intCast(state.leading_representation[leading_zeros])) << @truncate(state.trailing_bits_per_value + center_bits);
+            v |= @as(u64, @intCast(state.trailing_representation[trailing_zeros])) << @truncate(center_bits);
+            v |= xor_result >> @truncate(trailing_zeros);
+            try state.buffer.write(v, @truncate(len));
+        }
+        return state.buffer.fill - starting_fill;
+    }
+    
+    pub fn bitWeight(x: u8) u64 {
+        std.debug.assert(x < 64);
+        return @as(u64, 1) << @truncate(x);
+    }
+    
+    pub fn findAppLong(state: *SerfXORCompress, lo: f64, hi: f64, v: f64) u64 {
+        var v_lo = lo;
+        var v_hi = hi;
+        var sign: u64 = 0;
+        if (lo >= 0) {
+            // both positive
+            // nothing to do
+        } else if (hi <= 0) {
+            // both negative
+            v_lo = -hi;
+            v_hi = -lo;
+            sign = 0x8000000000000000;
+        } else if (state.stored_val >> 63 == 0) {
+            // consider only positive side to make more leading zeros
+            v_lo = 0;
+        } else {
+            // consider only negative side to make more leading zeros
+            v_lo = 0;
+            v_hi = -lo;
+            sign = 0x8000000000000000;
+        }
+        return findAppLongSign(v_lo, v_hi, sign, v, state.stored_val, state.max_diff, @floatFromInt(state.adjust_digit));
+    }
+    
+    pub fn findAppLongSign(min_d: f64, max_d: f64, sign: u64, original: f64, last_long: u64, max_diff: f64, adjust_digit: f64) u64 {
+        // mask off sign bit
+        const min = @as(u64, @bitCast(min_d)) & 0x7fffffffffffffff;
+        const max: u64 = @bitCast(max_d);
+        const leading_zeros = @clz(min ^ max);
+        
+        var front_mask = @as(u64, 0xffffffffffffffff) << @truncate(64 - leading_zeros);
+        var shift = 64 - @as(i64, @intCast(leading_zeros));
+        
+        var result: i64 = 0;
+        var diff: f64 = 0;
+        var append: u64 = 0;
+        
+        while (shift >= 0) {
+            const front = front_mask & min;
+            const rear = (~front_mask) & last_long;
+            
+            append = rear | front;
+            
+            const cond1: bool = ((append >= min) and (append <= max));
+            
+            // the way this is written in the original implementation suggests
+            // that they want this to compile to a CMOV instruction
+            if (cond1) {
+                result = @as(i64, @bitCast(append ^ @as(u64, @bitCast(sign))));
+            } else {
+                result = 0;
+            }
+            
+            diff = @as(f64, @bitCast(result)) - adjust_digit - original;
+            var diff_satisfied = (diff >= -max_diff) and (diff <= max_diff);
+            
+            if (cond1 and diff_satisfied) {
+                return @bitCast(result);
+            }
+            
+            append = (append + bitWeight(@intCast(shift))) & 0x7fffffffffffffff;
+            
+            const cond2: bool = append <= max;
+            // again, way this is written in the original impl suggests that they want this to compile to a CMOV
+            if (cond2) {
+                result = @as(i64, @bitCast(append ^ sign));
+            } else {
+                result = 0;
+            }
+            
+            diff = @as(f64, @bitCast(result)) - adjust_digit - original;
+            diff_satisfied = (diff >= -max_diff) and (diff <= max_diff);
+            
+            if (cond2 and diff_satisfied) {
+                return @bitCast(result);
+            }
+            
+            front_mask >>= 1;
+            shift -= 1;
+        }
+        
+        // can't find a value that satifies constraints, return original value
+        return @as(u64, @bitCast(original + adjust_digit));
+    }
+};
+
+pub const SerfXORDecompress = struct {
+    input: []const u8,
+    buffer: BitStream,
+    adjust_digit: u64,
+    window_size: u64,
+    leading_representation: SmallUnmanagedArrayList,
+    trailing_representation: SmallUnmanagedArrayList,
+    leading_bits_per_value: u32,
+    trailing_bits_per_value: u32,
+    stored_leading_zeros: u32,
+    stored_trailing_zeros: u32,
+    number_of_values: u64,
+    stored_val: u64,
+
+    stored_next_value: f64,
+    have_stored_next_value: bool,
+    
+    pub fn start(adjust_digit: u64, window_size: u64, input: []const u8) SerfXORDecompress {
+        var state = SerfXORDecompress {
+            .input = input,
+            .buffer = BitStream.makeFromArrayUnmanaged(@constCast(input)),
+            .adjust_digit = adjust_digit,
+            .window_size = window_size,
+            .leading_representation = SmallUnmanagedArrayList.init(),
+            .trailing_representation = SmallUnmanagedArrayList.init(),
+            .leading_bits_per_value = 3,
+            .trailing_bits_per_value = 3,
+            .stored_leading_zeros = 0,
+            .stored_trailing_zeros = 0,
+            
+            .number_of_values = 0,
+            .stored_val = 0,
+            .stored_next_value = 0,
+            .have_stored_next_value = false,
+        };
+        state.buffer.buffer.items.len = input.len;
+
+        state.leading_representation.len = 8;
+        state.leading_representation.items[0] = 0;
+        state.leading_representation.items[1] = 8;
+        state.leading_representation.items[2] = 12;
+        state.leading_representation.items[3] = 16;
+        state.leading_representation.items[4] = 18;
+        state.leading_representation.items[5] = 20;
+        state.leading_representation.items[6] = 22;
+        state.leading_representation.items[7] = 24;
+
+        state.trailing_representation.len = 8;
+        state.trailing_representation.items[0] = 0;
+        state.trailing_representation.items[1] = 22;
+        state.trailing_representation.items[2] = 28;
+        state.trailing_representation.items[3] = 32;
+        state.trailing_representation.items[4] = 36;
+        state.trailing_representation.items[5] = 40;
+        state.trailing_representation.items[6] = 42;
+        state.trailing_representation.items[7] = 46;
+
+        return state;
+    }
+    
+    pub fn readNextValue(state: *SerfXORDecompress) f64 {
+        if (!state.have_stored_next_value) {
+            state.readAndStoreNextValue();
+        }
+        state.have_stored_next_value = false;
+        return state.stored_next_value;
+    }
+
+    // TODO: need to have this return an error so I can just keep doing it until it returns an error (that error being: can't read more, boss)
+    pub fn readAndStoreNextValue(state: *SerfXORDecompress) void {
+        if (state.have_stored_next_value) {
+            return; // no-op
+        }
+
+        if (state.number_of_values >= state.window_size) {
+            state.updatePositionsIfNeeded();
+        }
+
+        state.nextValueInternal();
+        state.number_of_values += 1;
+        state.stored_next_value = @as(f64, @bitCast(state.stored_val)) - @as(f64, @floatFromInt(state.adjust_digit));
+        state.have_stored_next_value = true;
+        return;
+    }
+
+    pub fn haveNextValue(state: *SerfXORDecompress) bool {
+        if (state.buffer.buffer.items.len == 0) {
+            return false;
+        }
+
+        if (state.buffer.fill >= (state.buffer.buffer.items.len * 8) - 1) {
+            return false;
+        }
+
+        if (!state.have_stored_next_value) {
+            state.readAndStoreNextValue();
+        }
+        // TODO: try to read ahead and see if there's a valid window + window end
+        return !std.math.isNan(state.stored_next_value);
+
+        // presumption: an entire window is gonna be no less than a byte
+        //return state.buffer.fill == 0 or !(state.number_of_values == 0 and state.buffer.fill > ((state.input.len - 1) * 8));
+    }
+
+    pub fn nextValueInternal(state: *SerfXORDecompress) void {
+        var value: u64 = 0;
+        var center_bits: u64 = 0;
+        if (state.buffer.readBit() == 1) {
+            // case 1
+            if (state.stored_leading_zeros + state.stored_trailing_zeros < 64) {
+                center_bits = 64 - state.stored_leading_zeros - state.stored_trailing_zeros;
+                value = state.buffer.read(@truncate(center_bits)) << @truncate(state.stored_trailing_zeros);
+            } else {
+                // no center bits to read
+            }
+            state.stored_val = state.stored_val ^ value;
+        } else if (state.buffer.readBit() == 0) {
+            // case 00
+            const lead_and_trail = state.buffer.read(state.leading_bits_per_value + state.trailing_bits_per_value);
+            const lead = lead_and_trail >> @truncate(state.trailing_bits_per_value);
+            const trail = ~(@as(u64, 0xffffffffffffffff) << @truncate(state.trailing_bits_per_value)) & lead_and_trail;
+
+            std.log.warn("lead_and_trail: {x}, lead: {x}, trail: {x},\n\tleading_bits_per_value: {}, trailing_bits_per_value: {}", .{lead_and_trail, lead, trail, state.leading_bits_per_value, state.trailing_bits_per_value});
+
+            assert(state.leading_representation.len > lead);
+            state.stored_leading_zeros = state.leading_representation.items[lead];
+
+            assert(state.trailing_representation.len > trail);
+            state.stored_trailing_zeros = state.trailing_representation.items[trail];
+
+            std.log.warn("\tstored leading z: {}, trailing z: {}", .{state.stored_leading_zeros, state.stored_trailing_zeros});
+
+            if (state.stored_leading_zeros + state.stored_trailing_zeros < 64) {
+                center_bits = @as(u64, 64) - state.stored_leading_zeros - state.stored_trailing_zeros;
+                value = state.buffer.read(@truncate(center_bits)) << @truncate(state.stored_trailing_zeros);
+            } else {
+                // not center bits to read
+            }
+            state.stored_val = state.stored_val ^ value;
+        } else {
+            // case 01
+            // nothing to do, stored val doesn't change
+        }
+    }
+
+    pub fn updatePositionsIfNeeded(state: *SerfXORDecompress) void {
+        if (state.buffer.readBit() == 1) {
+            state.updateLeadingRepresentation();
+            state.updateTrailingRepresentation();
+        }
+        state.number_of_values = 0;
+    }
+
+    pub fn updateLeadingRepresentation(state: *SerfXORDecompress) void {
+        var num = state.buffer.read(5);
+        if (num == 0) {
+            num = 32;
+        }
+        state.leading_bits_per_value = PostOfficeSolver.position_length_2bits[num];
+        state.leading_representation.len = @truncate(num);
+        for (0..num) |i| {
+            state.leading_representation.items[i] = @truncate(state.buffer.read(6));
+        }
+    }
+
+    pub fn updateTrailingRepresentation(state: *SerfXORDecompress) void {
+        var num = state.buffer.read(5);
+        if (num == 0) {
+            num = 32;
+        }
+        state.trailing_bits_per_value = PostOfficeSolver.position_length_2bits[num];
+        state.trailing_representation.len = @truncate(num);
+        for (0..num) |i| {
+            state.trailing_representation.items[i] = @truncate(state.buffer.read(6));
+        }
+    }
+};
+
+const SmallUnmanagedArrayList = struct {
+    items: [64]u32,
+    len: u32,
+
+    pub fn init() SmallUnmanagedArrayList {
+        return SmallUnmanagedArrayList {
+            .items = [64]u32 {
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+            },
+            .len = 0,
+        };
+    }
+
+    pub fn initLen(len: u32) SmallUnmanagedArrayList {
+        var self = init();
+        self.len = len;
+        return self;
+    }
+
+    pub fn zero(self: *SmallUnmanagedArrayList) void {
+        for (0..64) |i| {
+            self.items[i] = 0;
+        }
+        self.len = 0;
+    }
+
+    pub fn push(self: *SmallUnmanagedArrayList, v: u32) void {
+        std.debug.assert(self.len < 64);
+        self.items[self.len] = v;
+        self.len += 1;
+    }
+};
+
+const default_window_size: u64 = 1024;
+
+fn maxDiffFromErrorBound(error_bound: f32) f64 {
+    return @floatCast(error_bound);
+}
+
+fn adjustDigitFromInput(input: []const f64) u64 {
+    var maximum: f64 = input[0];
+    var minimum: f64 = input[0];
+    for (input) |v| {
+        maximum = @max(maximum, v);
+        minimum = @min(minimum, v);
+    }
+    // NOTE (sio): taken from Serf/test/adjust_digit_calculator.cpp
+    const u = @as(u6, @truncate(@as(u32, @intFromFloat(@ceil(@log2(@floor(maximum) - @floor(minimum) + 1))))));
+    const lambda = (@as(i64, 1) << u) - @as(i64, @intFromFloat(@floor(minimum)));
+    return @max(0, lambda);
+}
+
+
+fn writeU64ToArrayList(out: *ArrayList(u8), value: u64) !void {
+    try out.append(@as(u8, @truncate(value >> 56)));
+    try out.append(@as(u8, @truncate(value >> 48)));
+    try out.append(@as(u8, @truncate(value >> 40)));
+    try out.append(@as(u8, @truncate(value >> 32)));
+    try out.append(@as(u8, @truncate(value >> 24)));
+    try out.append(@as(u8, @truncate(value >> 16)));
+    try out.append(@as(u8, @truncate(value >> 8)));
+    try out.append(@as(u8, @truncate(value)));
+}
+
+fn readU64FromArray(input: []const u8) u64 {
+    return (@as(u64, input[0]) << 56)
+        | (@as(u64, input[1]) << 48)
+        | (@as(u64, input[2]) << 40)
+        | (@as(u64, input[3]) << 32)
+        | (@as(u64, input[4]) << 24)
+        | (@as(u64, input[5]) << 16)
+        | (@as(u64, input[6]) << 8)
+        | (@as(u64, input[7]));
+}
+
+test "serf-xor can compress and decompress random quantizable data" {
+    var prng = std.Random.DefaultPrng.init(@bitCast(std.time.milliTimestamp()));
+    const random = prng.random();
+    for (1..100000) |inputs_length| {
+        const error_bound = Tester.generateBoundedRandomValue(f64, 0.00001, 30.0, random);
+        std.log.warn("inputs length {} error bound {}", .{ inputs_length, error_bound });
+
+        var inputs = try std.ArrayList(f64).initCapacity(testing.allocator, inputs_length);
+        defer inputs.deinit();
+        var prev: f64 = 0.0;
+        for (0..inputs_length) |_| {
+            const val = Tester.generateBoundedRandomValue(f64, prev - (error_bound * 10000), prev + (error_bound * 10000), random);
+            try inputs.append(val);
+            prev = val;
+        }
+
+        var outputs = std.ArrayList(u8).init(testing.allocator);
+        defer outputs.deinit();
+
+        try compress(inputs.items, &outputs, @floatCast(error_bound));
+
+        var decompressed = std.ArrayList(f64).init(testing.allocator);
+        defer decompressed.deinit();
+
+        try decompress(outputs.items, &decompressed);
+
+        std.log.warn("inputs len: {}, decompressed len: {}", .{ inputs.items.len, decompressed.items.len });
+        for (inputs.items, decompressed.items) |expected, actual| {
+            try testing.expectApproxEqAbs(expected, actual, error_bound);
+        }
+    }
+}
+
+// TODO: serf-xor tests

--- a/src/tersets.zig
+++ b/src/tersets.zig
@@ -30,6 +30,8 @@ const bottom_up = @import("line_simplification/bottom_up.zig");
 const rle_enconding = @import("lossless_encoding/run_length_encoding.zig");
 const bitpacked_quantization = @import("quantization/bitpacked_quantization.zig");
 const non_linear_approximation = @import("functional_approximation/non_linear_approximation.zig");
+const serf_qt = @import("serf/serf_qt.zig");
+const serf_xor = @import("serf/serf_xor.zig");
 
 /// The errors that can occur in TerseTS.
 pub const Error = error{
@@ -62,6 +64,8 @@ pub const Method = enum {
     BitPackedQuantization,
     RunLengthEncoding,
     NonLinearApproximation,
+    SerfQt,
+    SerfXor,
 };
 
 /// Compress `uncompressed_values` within `error_bound` using `method` and returns the results
@@ -206,6 +210,20 @@ pub fn compress(
                 error_bound,
             );
         },
+        .SerfQt => {
+            try serf_qt.compress(
+                uncompressed_values,
+                &compressed_values,
+                error_bound,
+            );
+        },
+        .SerfXor => {
+            try serf_xor.compress(
+                uncompressed_values,
+                &compressed_values,
+                error_bound,
+            );
+        },
     }
     try compressed_values.append(@intFromEnum(method));
     return compressed_values;
@@ -279,6 +297,12 @@ pub fn decompress(
         },
         .NonLinearApproximation => {
             try non_linear_approximation.decompress(allocator, compressed_values_slice, &decompressed_values);
+        },
+        .SerfQt => {
+            try serf_qt.decompress(compressed_values_slice, &decompressed_values);
+        },
+        .SerfXor => {
+            try serf_xor.decompress(compressed_values_slice, &decompressed_values);
         },
     }
 

--- a/src/utilities/encoding.zig
+++ b/src/utilities/encoding.zig
@@ -1,0 +1,291 @@
+// Copyright 2025 TerseTS Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const std = @import("std");
+const assert = std.debug.assert;
+const testing = std.testing;
+
+const Tester = @import("../tester.zig");
+
+// signed in, unsigned of same size out
+pub fn zigzagEncode(v: i64) u64 {
+    return @bitCast((v << 1) ^ (v >> 63));
+}
+
+pub fn zigzagDecode(u: u64) i64 {
+    const v = @as(i64, @bitCast(u));
+    return (v >> 1) ^ (-(v & 1));
+}
+
+pub fn bitIdxRead(s: []const u8, idx: u64) u8 {
+    return (s[idx >> 3] >> @truncate(idx & 0x7)) & 1;
+}
+
+pub fn bitIdxWrite(s: []u8, idx: u64, v: u8) void {
+    const byte_idx = idx >> 3;
+    const bit_idx = @as(u3, @truncate(idx & 0x7));
+    
+    const tmp = s[byte_idx];
+    const clear = tmp & ~(@as(u8, 1) << bit_idx);
+    const set = clear | ((v & 1) << bit_idx);
+    s[byte_idx] = set;
+}
+
+pub fn onlyZerosFollow(stream: []const u8, stream_index: u64) bool {
+    for (stream_index..(@bitSizeOf(u8) * stream.len)) |i| {
+        if (0 != bitIdxRead(stream, i)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// necessary because Zig doesn't support multiple return values properly
+pub const GammaResult = struct {
+    leading_zeros: u64,
+    trailing_part: u64,
+};
+
+// trailing bit length is same as number of leading zeroes
+pub fn gammaEncodeSingle(value: u64) GammaResult {
+    assert(value > 0);
+    const leading_zeros = 63 - @as(u64, @intCast(@clz(value)));
+    return GammaResult {
+        .leading_zeros = leading_zeros, // largest power of 2 in value
+        .trailing_part = value & ~(@as(u64, 1) << @truncate(leading_zeros)),
+    };
+}
+
+pub fn gammaEncodeIter(value: u64, stream: []u8, stream_index: *u64) void {
+    const start = stream_index.*;
+    const gres = gammaEncodeSingle(value);
+    const end = start + 1 + (gres.leading_zeros * 2);
+    
+    // TODO (sio): this can be done more efficiently I'm sure
+    for (start..(start + gres.leading_zeros)) |i| {
+        bitIdxWrite(stream, i, 0);
+    }
+    bitIdxWrite(stream, start + gres.leading_zeros, 1);
+
+    if (gres.leading_zeros > 0) {
+        // write trailing part
+        for (0..gres.leading_zeros) |i| {
+            const v = (gres.trailing_part >> @truncate(i)) & 1;
+            bitIdxWrite(stream, start + 1 + gres.leading_zeros + i, @as(u8, @truncate(v)));
+        }
+    }
+    
+    stream_index.* = end;
+}
+
+pub fn gammaEncodeSlice(values: []const u64, stream: []u8) void {
+    var stream_index: u64 = 0;
+    for (values) |v| {
+        gammaEncodeIter(v, stream, &stream_index);
+    }
+}
+
+// returns how many bytes the elias gamma encoded stream would occupy
+pub fn gammaEncodeResultSize(values: []const u64) u64 {
+    var encoded_size: u64 = 0;
+    
+    for (values) |v| {
+        const gres = gammaEncodeSingle(v);
+        encoded_size += 1 + (gres.leading_zeros * 2);
+    }
+    
+    // convert from bit count to byte count
+    encoded_size += 7; // ensure that iff encoded_size % 8 > 0 we add another byte
+    encoded_size /= 8;
+    
+    return encoded_size;
+}
+
+pub fn gammaDecodeIter(stream: []const u8, stream_index: *u64) u64 {
+    var value: u64 = 0;
+    
+    const start = stream_index.*;
+    var zero_counter: u64 = 0;
+    // count 0s until first 1
+    while (0 == bitIdxRead(stream, start + zero_counter)) {
+        zero_counter += 1;
+    }
+    
+    // eat the 1 and as many bits after it as we've seen zeros before
+    value |= @as(u64, bitIdxRead(stream, start + zero_counter)) << @truncate(zero_counter);
+    for (0..zero_counter) |i| {
+        const idx = i + 1 + zero_counter;
+        const v = bitIdxRead(stream, start + idx);
+        value |= @as(u64, @intCast(v)) << @truncate(i);
+    }
+    
+    stream_index.* = start + zero_counter + 1 + zero_counter;
+    return value;
+}
+
+pub fn gammaDecodeSlice(stream: []const u8, out: []u64) void {
+    var stream_index: u64 = 0;
+    const end: u64 = stream.len * @bitSizeOf(u8);
+    var i: u64 = 0;
+    while (i < out.len and (stream_index < end)) {
+        if (onlyZerosFollow(stream, stream_index)) {
+            break;
+        }
+        out[i] = gammaDecodeIter(stream, &stream_index);
+        i += 1;
+    }
+}
+
+// returns how many elements are encoded into stream
+pub fn gammaDecodeElemCount(stream: []const u8) u64 {
+    var stream_index: u64 = 0;
+    const end: u64 = stream.len * @bitSizeOf(u8);
+    var i: u64 = 0;
+    while (stream_index < end) {
+        if (onlyZerosFollow(stream, stream_index)) {
+            break;
+        }
+        _ = gammaDecodeIter(stream, &stream_index);
+        i += 1;
+    }
+    return i;
+}
+
+test "zigzag encode -> decode works" {
+    var prng = std.Random.DefaultPrng.init(@bitCast(std.time.milliTimestamp()));
+    const random = prng.random();
+    const maximum = (@as(i64, 1) << 62) - 1;
+    const minimum = -maximum;
+    for (0..100000) |_| {
+        const v = random.intRangeAtMost(i64, minimum, maximum);
+        try testing.expectEqual(v, zigzagDecode(zigzagEncode(v)));
+    }
+}
+
+test "zigzag encoding of trivial values produces correct result" {
+    const Tst = struct { in: i64, out: u64 };
+    const result_tbl = [_]Tst {
+        .{ .in = 0, .out = 0 },
+        .{ .in = -1, .out = 1 },
+        .{ .in = 1, .out = 2 },
+        .{ .in = -2, .out = 3 },
+        .{ .in = 2, .out = 4 },
+        .{ .in = -3, .out = 5 },
+        .{ .in = 3, .out = 6 },
+    };
+    for (result_tbl) |tst| {
+        try testing.expectEqual(tst.out, zigzagEncode(tst.in));
+    }
+}
+
+test "elias gamma encode of trivial numbers works correctly" {
+    const result_tbl = [_]GammaResult {
+    .{ .leading_zeros = 0, .trailing_part = 0 }, // 1
+    .{ .leading_zeros = 1, .trailing_part = 0 }, // 2
+    .{ .leading_zeros = 1, .trailing_part = 1 }, // 3
+    .{ .leading_zeros = 2, .trailing_part = 0 }, // 4
+    .{ .leading_zeros = 2, .trailing_part = 1 }, // 5
+    .{ .leading_zeros = 2, .trailing_part = 2 }, // 6
+    .{ .leading_zeros = 2, .trailing_part = 3 }, // 7
+    .{ .leading_zeros = 3, .trailing_part = 0 }, // 8
+    .{ .leading_zeros = 3, .trailing_part = 1 }, // 9
+    .{ .leading_zeros = 3, .trailing_part = 2 }, // 10
+    .{ .leading_zeros = 3, .trailing_part = 3 }, // 11
+    .{ .leading_zeros = 3, .trailing_part = 4 }, // 12
+    .{ .leading_zeros = 3, .trailing_part = 5 }, // 13
+    .{ .leading_zeros = 3, .trailing_part = 6 }, // 14
+    .{ .leading_zeros = 3, .trailing_part = 7 }, // 15
+    .{ .leading_zeros = 4, .trailing_part = 0 }, // 16
+    };
+    for (result_tbl, 0..) |expected, i| {
+        const gres = gammaEncodeSingle(i + 1);
+        try testing.expectEqual(expected, gres);
+    }
+}
+
+test "elias gamma result size for trivial numbers is correct" {
+    for (1..32) |i| {
+        const v = [1]u64 { i };
+        if (i >= 1 and i < 15) {
+            try testing.expectEqual(1, gammaEncodeResultSize(&v));
+        } else if (i >= 16) {
+            try testing.expectEqual(2, gammaEncodeResultSize(&v));
+        }
+    }
+}
+
+test "elias gamma encode/decode iter of trivial numbers works correctly" {
+    const data = [_][2]u8 {
+        // { in, out }
+        [2]u8 {  1, 0b1 },
+        [2]u8 {  2, 0b010 },
+        [2]u8 {  3, 0b110 },
+        [2]u8 {  4, 0b00100 },
+        [2]u8 {  5, 0b01100 },
+        [2]u8 {  6, 0b10100 },
+        [2]u8 {  7, 0b11100 },
+        [2]u8 {  8, 0b0001000 },
+        [2]u8 {  9, 0b0011000 },
+        [2]u8 { 10, 0b0101000 },
+        [2]u8 { 11, 0b0111000 },
+        [2]u8 { 12, 0b1001000 },
+        [2]u8 { 13, 0b1011000 },
+        [2]u8 { 14, 0b1101000 },
+        [2]u8 { 15, 0b1111000 },
+    };
+    for (data) |d| {
+        const n: u64 = @intCast(d[0]);
+        var buffer = [8]u8 { 0, 0, 0, 0, 0, 0, 0, 0 };
+        var index: u64 = 0;
+        gammaEncodeIter(n, &buffer, &index);
+        try testing.expectEqual(d[1], buffer[0]);
+        index = 0;
+        const res = gammaDecodeIter(&buffer, &index);
+        try testing.expectEqual(d[0], @as(u8, @truncate(res)));
+    }
+}
+
+test "elias gamma encode into decode" {
+    var prng = std.Random.DefaultPrng.init(@bitCast(std.time.milliTimestamp()));
+    const random = prng.random();
+    for (1..1000) |inputs_length| {
+        var inputs = try std.ArrayList(u64).initCapacity(testing.allocator, inputs_length);
+        defer inputs.deinit();
+        try inputs.appendNTimes(0, inputs_length);
+        for (0..inputs_length) |i| {
+            inputs.items[i] = random.intRangeAtMost(u64, 1, @as(u64, 1) << 63);
+        }
+
+        const encode_result_length = gammaEncodeResultSize(inputs.items[0..inputs_length]);
+        var encode_result = try std.ArrayList(u8).initCapacity(testing.allocator, encode_result_length);
+        defer encode_result.deinit();
+        try encode_result.appendNTimes(0, encode_result_length);
+
+        gammaEncodeSlice(inputs.items[0..inputs_length], encode_result.items[0..encode_result_length]);
+
+        const encoded_count = gammaDecodeElemCount(encode_result.items[0..encode_result_length]);
+        try testing.expectEqual(inputs_length, encoded_count);
+
+        var decode_result = try std.ArrayList(u64).initCapacity(testing.allocator, encoded_count);
+        defer decode_result.deinit();
+        try decode_result.appendNTimes(0, encoded_count);
+
+        gammaDecodeSlice(encode_result.items[0..encode_result_length], decode_result.items[0..encoded_count]);
+
+        for (0..encoded_count) |i| {
+            try testing.expectEqual(inputs.items[i], decode_result.items[i]);
+        }
+    }
+}
+


### PR DESCRIPTION
Caveat as of this time: Serf-Xor in this form does not work and accordingly, it does not pass tests.

### Summary
This PR implements Serf-Qt, Serf-Xor, Elias Gamma Encoding, Zigzag Encoding.

Based on [Serf: Streaming Error-Bounded Floating-Point Compression](http://kangry.net/paper/Serf_SIGMOD2025.pdf).

### Files Added/Modified

- New method files: `src/serf/serf_qt.zig` and `src/serf/serf_xor.zig`
- `src/utilities/encoding.zig` contains an implementation of Elias Gamma Encoding and Zigzag Encoding
- `src/utilities/shared_structs.zig`: added a BitStream implementation to read and write bit streams
- `default.nix`: simplify working with TerseTS on NixOS by specifying required zig version and other dependencies in a way Nix (the package manager) easily understands - this could be expanded to being a full package definition with viable build script relatively easily, but at this time it is not.

### Testing

- All newly added code has tests. I believe I've not achieved 100% coverage, but reasonable use is tested.

