### PR TITLE
Change macOS Version at Github Workflow

### DIFF
--- a/.github/workflows/zig-build-lint-and-test-on-pr-and-push.yml
+++ b/.github/workflows/zig-build-lint-and-test-on-pr-and-push.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        # macos-latest-large is used instead of macos-latest as Zig compiles to x86_64 on mac.
+        # macos-15-intel is used instead of macos-latest as Zig compiles to x86_64 on mac.
         operating-system: [ubuntu-latest, macos-15-intel, windows-latest]
 
     steps:


### PR DESCRIPTION
### Summary

The macOS 13 runner image will be retired by December 4th, 2025. This PR then changes our workflow to `macos-15-intel`, as suggested, for users who require the `x86_64` (Intel) architecture.