### PR TITLE
Use macos-latest for GitHub Actions

### DIFF
--- a/.github/workflows/zig-build-lint-and-test-on-pr-and-push.yml
+++ b/.github/workflows/zig-build-lint-and-test-on-pr-and-push.yml
@@ -28,8 +28,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        # macos-15-intel is used instead of macos-latest as Zig compiles to x86_64 on mac.
-        operating-system: [ubuntu-latest, macos-15-intel, windows-latest]
+        operating-system: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
### Summary
This PR makes GitHub Actions use `macos-latest` as Zig now produces `arm` binaries on my M3 Mac. 
