### PR TITLE
Add reconstruction condition in Bit-quantization

### DIFF
--- a/src/lossy_compression/functional_approximation/poor_mans_compression.zig
+++ b/src/lossy_compression/functional_approximation/poor_mans_compression.zig
@@ -64,7 +64,7 @@ pub fn compressMidrange(
 
         // If the error bound is zero, we only append a new value if the next value is different.
         // Without this check low precision values would pass the error bound check and lose information.
-        // For example is minimum is 34.5e-301 and maximum is 4.5e-301, the error bound check would pass
+        // For example if minimum is 34.5e-301 and maximum is 4.5e-301, the error bound check would pass
         // since 34.5e-301 - 4.5e-301 == 0 due to precision loss.
         if (((error_bound == 0) and (nextMaximum != nextMinimum)) or (nextMaximum - nextMinimum) > 2 * error_bound) {
             const compressed_value: f64 = @floatCast((maximum + minimum) / 2);
@@ -125,7 +125,7 @@ pub fn compressMean(
 
         // If the error bound is zero, we only append a new value if the next value is different.
         // Without this check low precision values would pass the error bound check and lose information.
-        // For example is minimum is 34.5e-301 and maximum is 4.5e-301, the error bound check would pass
+        // For example if minimum is 34.5e-301 and maximum is 4.5e-301, the error bound check would pass
         // since 34.5e-301 - 4.5e-301 == 0 due to precision loss.
         if (error_bound == 0) {
             if (nextMaximum != nextMinimum) {

--- a/src/lossy_compression/value_representation/bitpacked_quantization.zig
+++ b/src/lossy_compression/value_representation/bitpacked_quantization.zig
@@ -79,7 +79,7 @@ pub fn compress(
         // If `bucket_size` is so small that adding it to `minimum_value` does nothing, then the
         // reconstruction grid collapses at `minimum_value` due to f64 precision.
         if (minimum_value + bucket_size == minimum_value) {
-            if (@abs(maximum_value - minimum_value) > error_bound) return Error.UnsupportedInput;
+            if (@as(f32, @floatCast(@abs(maximum_value - minimum_value))) > error_bound) return Error.UnsupportedInput;
         } else {
             // Check whether maximum_value is representable within the error bound under the
             // same quantize+reconstruct. If not, the method cannot be applied to this input since it
@@ -87,11 +87,11 @@ pub fn compress(
             const maximum_quantized_value: f64 = @round((maximum_value - minimum_value) / bucket_size);
             const reconstructed_maximum_value: f64 = minimum_value + maximum_quantized_value * bucket_size;
 
-            if (@abs(reconstructed_maximum_value - maximum_value) > error_bound) return Error.UnsupportedInput;
+            if (@as(f32, @floatCast(@abs(reconstructed_maximum_value - maximum_value))) > error_bound) return Error.UnsupportedInput;
         }
     }
 
-    // Append the minimum value to the header of the compressed values.
+    // Append the bucket size to the header of the compressed values.
     try shared_functions.appendValue(allocator, f64, bucket_size, compressed_values);
 
     //Intermediate quantized values.
@@ -221,7 +221,7 @@ pub fn decompress(
 
 test "bitpacked quantization can compress and decompress bounded values" {
     const allocator = testing.allocator;
-    // Use only tighted bounded random values for this test.
+    // Use only tightly bounded random values for this test.
     // BitPackedQuantization requires bounded values to operate correctly.
     // Other data distributions may generate unbounded values which are not supported.
     const data_distributions = &[_]tester.DataDistribution{.TightlyBoundedRandomValues};


### PR DESCRIPTION
### Summary

This PR adds a condition to check that the reconstructed value after quantization is within the error bound. The opposite can happen due to the limited floating-point precision when summing and subtracting the minimum value. To avoid triggering this error without control, I changed the way floating points are generated for testing bit-quantization. 

