### PR TITLE
Add warning to users that TerseTS is not ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
   <img src="docs/tersets.svg" alt="TerseTS", width="400">
 </h1>
 
+:warning: **The current version of TerseTS is beta software and not yet ready for production use.**
+
 TerseTS is a library that provides methods for lossless and lossy compressing time series. To match existing literature, the lossy compression methods are organized in the hierarchy below based on [Time Series Compression Survey](https://dl.acm.org/doi/10.1145/3560814). Each category represents a distinct approach to time series compression. The library is implemented in Zig and provides a Zig-API and C-API with [bindings](#usage) for other languages.
 
 <p align="center">


### PR DESCRIPTION
### Summary
This PR adds a warning to the README to make it clear to users that TerseTS is not yet ready for production use. When we have sufficient testing to trust that all of the included compression methods are implemented correctly according to the original papers and reference implementation, and will not lose data when used, we can replace it with information about how we ensured the implementation is production-ready.