### PR TITLE
Update Zig to 0.16.0

### DIFF
--- a/.github/workflows/zig-fmt-build-and-test-on-pr-and-push.yml
+++ b/.github/workflows/zig-fmt-build-and-test-on-pr-and-push.yml
@@ -84,14 +84,14 @@ jobs:
     - name: Rustup Update
       run: rustup update
     - name: Cargo Build
-      run: cargo build --verbose --all-targets
+      run: cargo build --verbose --release --all-targets
       working-directory: bindings/rust
     - name: Cargo Clippy
-      run: cargo clippy --verbose --all-targets
+      run: cargo clippy --verbose --release --all-targets
       working-directory: bindings/rust
     - name: Cargo Doc
-      run: cargo doc --verbose --no-deps
+      run: cargo doc --verbose --release --no-deps
       working-directory: bindings/rust
     - name: Cargo Test
-      run: cargo test --verbose --all-targets -- --nocapture
+      run: cargo test --verbose --release --all-targets -- --nocapture
       working-directory: bindings/rust

--- a/.github/workflows/zig-fmt-build-and-test-on-pr-and-push.yml
+++ b/.github/workflows/zig-fmt-build-and-test-on-pr-and-push.yml
@@ -40,7 +40,7 @@ jobs:
     # Zig
     - uses: mlugg/setup-zig@v2
       with:
-        version: 0.15.2
+        version: 0.16.0
     - name: Zig Fmt Check
       run: zig fmt --check .
       if: runner.os != 'Windows' # Windows disagrees with Ubuntu and macOS.

--- a/src/capi.zig
+++ b/src/capi.zig
@@ -40,9 +40,9 @@ pub const Indices = Array(usize);
 pub const Coefficients = Array(f64);
 
 /// Compress `uncompressed_values` to `compressed_values` using `method` according to
-/// `configuration`. The General Purpose Allocator `allocator` is passed as a parameter to TerseTS
-/// for memory management in the compression methods. On success zero is returned, and the following
-/// non-zero values are returned on errors:
+/// `configuration`. The Heap Allocator `allocator` is passed as a parameter to TerseTS for memory
+/// management in the compression methods. On success zero is returned, and the following non-zero
+/// values are returned on errors:
 /// - 1) Unknown compression method.
 /// - 2) Unsupported input.
 /// - 3) Invalid configuration.
@@ -53,6 +53,7 @@ pub const Coefficients = Array(f64);
 /// - 8) Byte stream error.
 /// - 9) Unsupported method.
 /// - 10) Out of memory.
+/// - 11) Write failed.
 export fn compress(
     uncompressed_values: UncompressedValues,
     compressed_values: *CompressedValues,
@@ -86,9 +87,9 @@ export fn compress(
 }
 
 /// Decompress `compressed_values` to `decompressed_values`. The method is encoded in the last byte
-/// of `compressed_values`. The General Purpose Allocator `allocator` is passed as a parameter to
-/// tersets for memory management in the decompression methods. On success zero is returned, and the
-/// following non-zero values are returned on errors:
+/// of `compressed_values`. The Heap Allocator `allocator` is passed as a parameter to tersets for
+/// memory management in the decompression methods. On success zero is returned, and the following
+/// non-zero values are returned on errors:
 /// - 1) Unknown compression method.
 /// - 2) Unsupported input.
 /// - 3) Invalid configuration.
@@ -99,6 +100,7 @@ export fn compress(
 /// - 8) Byte stream error.
 /// - 9) Unsupported method.
 /// - 10) Out of memory.
+/// - 11) Write failed.
 export fn decompress(
     compressed_values: CompressedValues,
     decompressed_values: *UncompressedValues,

--- a/src/capi.zig
+++ b/src/capi.zig
@@ -25,8 +25,7 @@ const Error = tersets.Error;
 const Method = tersets.Method;
 
 /// Global memory allocator used by tersets.
-var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-const allocator = gpa.allocator();
+const allocator = std.heap.smp_allocator;
 
 /// A pointer to uncompressed values and the number of values.
 pub const UncompressedValues = Array(f64);
@@ -277,6 +276,7 @@ fn errorToIndex(err: Error) i32 {
         Error.ByteStreamError => return 8,
         Error.UnsupportedMethod => return 9,
         Error.OutOfMemory => return 10,
+        Error.WriteFailed => return 11,
     }
 }
 

--- a/src/lossy_compression/functional_approximation/sim_piece.zig
+++ b/src/lossy_compression/functional_approximation/sim_piece.zig
@@ -672,7 +672,7 @@ test "f64 context can hash" {
         f64,
     ).init(allocator);
     defer f64_hash_map.deinit();
-    var rnd = std.Random.DefaultPrng.init(@as(u64, @bitCast(std.time.milliTimestamp())));
+    var rnd = std.Random.DefaultPrng.init(@as(u64, @bitCast(tester.milliTimestamp())));
 
     // Add 100 elements into the HashMap. For each element, add two more with small deviation of
     // 1e-16 to test that the numbers are different and a new key is created.
@@ -710,7 +710,7 @@ test "hashmap can map f64 to segment metadata array list" {
     var f64_usize_hash_map = shared_structs.HashMapf64(usize).init(allocator);
     defer f64_usize_hash_map.deinit();
 
-    var rnd = std.Random.DefaultPrng.init(@as(u64, @bitCast(std.time.milliTimestamp())));
+    var rnd = std.Random.DefaultPrng.init(@as(u64, @bitCast(tester.milliTimestamp())));
 
     for (0..200) |_| {
         const rand_number = @floor((rnd.random().float(f64) - 0.5) * 100) / 10;

--- a/src/lossy_compression/functional_approximation/sim_piece.zig
+++ b/src/lossy_compression/functional_approximation/sim_piece.zig
@@ -24,7 +24,6 @@ const std = @import("std");
 const math = std.math;
 const mem = std.mem;
 const rand = std.Random;
-const time = std.time;
 const testing = std.testing;
 const ArrayList = std.ArrayList;
 const Allocator = std.mem.Allocator;

--- a/src/lossy_compression/line_simplification/visvalingam_whyatt.zig
+++ b/src/lossy_compression/line_simplification/visvalingam_whyatt.zig
@@ -20,7 +20,6 @@
 const std = @import("std");
 const mem = std.mem;
 const math = std.math;
-const time = std.time;
 const testing = std.testing;
 const ArrayList = std.ArrayList;
 const Allocator = mem.Allocator;

--- a/src/lossy_compression/line_simplification/visvalingam_whyatt.zig
+++ b/src/lossy_compression/line_simplification/visvalingam_whyatt.zig
@@ -371,7 +371,7 @@ pub fn testAreaWithinErrorBound(
 
 test "vw compress and decompress with zero error bound" {
     // Initialize a random number generator.
-    const seed: u64 = @bitCast(time.milliTimestamp());
+    const seed: u64 = @bitCast(tester.milliTimestamp());
     var prng = std.Random.DefaultPrng.init(seed);
     const random = prng.random();
 

--- a/src/lossy_compression/value_representation/bitpacked_quantization.zig
+++ b/src/lossy_compression/value_representation/bitpacked_quantization.zig
@@ -125,7 +125,7 @@ pub fn compress(
     const large_limit = 0xFFFFFFFF; // Fits in 32 bits.
 
     // Bit-wise packing with fixed-length header.
-    var bit_writer = try shared_structs.BitWriter(.little).init(allocator);
+    var bit_writer = try shared_structs.BitWriter(.big).init(allocator);
     defer bit_writer.deinit();
 
     for (quantized_values.items) |val| {
@@ -168,7 +168,7 @@ pub fn decompress(
 
     // Create a bit reader from remaining bytes.
     const reader = Reader.fixed(compressed_values[16..]);
-    var bit_reader = shared_structs.BitReader(.little).init(reader);
+    var bit_reader = shared_structs.BitReader(.big).init(reader);
     var decompressed_value: f64 = 0.0;
 
     // Convert minimum_value to its ordered bit representation.

--- a/src/lossy_compression/value_representation/bitpacked_quantization.zig
+++ b/src/lossy_compression/value_representation/bitpacked_quantization.zig
@@ -125,8 +125,7 @@ pub fn compress(
     const large_limit = 0xFFFFFFFF; // Fits in 32 bits.
 
     // Bit-wise packing with fixed-length header.
-    var bit_writer = try shared_structs.BitWriter.init(allocator);
-    defer bit_writer.deinit();
+    var bit_writer = try shared_structs.BitWriter.init(allocator, compressed_values);
 
     for (quantized_values.items) |val| {
         if (val <= small_limit) {
@@ -149,7 +148,6 @@ pub fn compress(
     }
 
     try bit_writer.flushBits();
-    try compressed_values.appendSlice(allocator, bit_writer.bytes.items);
 }
 
 /// Decompress `compressed_values` produced by "Bucket Quantization" and "Bit-Packing". The function

--- a/src/lossy_compression/value_representation/bitpacked_quantization.zig
+++ b/src/lossy_compression/value_representation/bitpacked_quantization.zig
@@ -125,7 +125,7 @@ pub fn compress(
     const large_limit = 0xFFFFFFFF; // Fits in 32 bits.
 
     // Bit-wise packing with fixed-length header.
-    var bit_writer = try shared_structs.BitWriter(.big).init(allocator);
+    var bit_writer = try shared_structs.BitWriter.init(allocator);
     defer bit_writer.deinit();
 
     for (quantized_values.items) |val| {
@@ -168,7 +168,7 @@ pub fn decompress(
 
     // Create a bit reader from remaining bytes.
     const reader = Reader.fixed(compressed_values[16..]);
-    var bit_reader = shared_structs.BitReader(.big).init(reader);
+    var bit_reader = shared_structs.BitReader.init(reader);
     var decompressed_value: f64 = 0.0;
 
     // Convert minimum_value to its ordered bit representation.

--- a/src/lossy_compression/value_representation/bitpacked_quantization.zig
+++ b/src/lossy_compression/value_representation/bitpacked_quantization.zig
@@ -24,9 +24,10 @@
 const std = @import("std");
 const math = std.math;
 const mem = std.mem;
-const io = std.io;
+const Io = std.Io;
 const testing = std.testing;
-const Writer = std.io.Writer;
+const Reader = std.Io.Reader;
+const Writer = std.Io.Writer;
 const ArrayList = std.ArrayList;
 const Allocator = mem.Allocator;
 
@@ -124,8 +125,8 @@ pub fn compress(
     const large_limit = 0xFFFFFFFF; // Fits in 32 bits.
 
     // Bit-wise packing with fixed-length header.
-    const writer = compressed_values.writer(allocator);
-    var bit_writer = shared_structs.bitWriter(.little, writer);
+    var writer = Writer.Allocating.init(allocator);
+    var bit_writer = shared_structs.bitWriter(.little, writer.writer);
 
     for (quantized_values.items) |val| {
         if (val <= small_limit) {
@@ -148,6 +149,7 @@ pub fn compress(
     }
 
     try bit_writer.flushBits();
+    try compressed_values.appendSlice(allocator, writer.toArrayList().items);
 }
 
 /// Decompress `compressed_values` produced by "Bucket Quantization" and "Bit-Packing". The function
@@ -165,8 +167,8 @@ pub fn decompress(
     const bucket_size: f64 = @bitCast(compressed_values[8..16].*);
 
     // Create a bit reader from remaining bytes.
-    var stream = io.fixedBufferStream(compressed_values[16..]);
-    var bit_reader = shared_structs.bitReader(.little, stream.reader());
+    const reader = Reader.fixed(compressed_values[16..]);
+    var bit_reader = shared_structs.bitReader(.little, reader);
     var decompressed_value: f64 = 0.0;
 
     // Convert minimum_value to its ordered bit representation.

--- a/src/lossy_compression/value_representation/bitpacked_quantization.zig
+++ b/src/lossy_compression/value_representation/bitpacked_quantization.zig
@@ -125,8 +125,8 @@ pub fn compress(
     const large_limit = 0xFFFFFFFF; // Fits in 32 bits.
 
     // Bit-wise packing with fixed-length header.
-    var writer = Writer.Allocating.init(allocator);
-    var bit_writer = shared_structs.bitWriter(.little, writer.writer);
+    var bit_writer = try shared_structs.BitWriter(.little).init(allocator);
+    defer bit_writer.deinit();
 
     for (quantized_values.items) |val| {
         if (val <= small_limit) {
@@ -149,7 +149,7 @@ pub fn compress(
     }
 
     try bit_writer.flushBits();
-    try compressed_values.appendSlice(allocator, writer.toArrayList().items);
+    try compressed_values.appendSlice(allocator, bit_writer.bytes.items);
 }
 
 /// Decompress `compressed_values` produced by "Bucket Quantization" and "Bit-Packing". The function
@@ -168,7 +168,7 @@ pub fn decompress(
 
     // Create a bit reader from remaining bytes.
     const reader = Reader.fixed(compressed_values[16..]);
-    var bit_reader = shared_structs.bitReader(.little, reader);
+    var bit_reader = shared_structs.BitReader(.little).init(reader);
     var decompressed_value: f64 = 0.0;
 
     // Convert minimum_value to its ordered bit representation.

--- a/src/lossy_compression/value_representation/histogram_representation.zig
+++ b/src/lossy_compression/value_representation/histogram_representation.zig
@@ -653,7 +653,7 @@ test "Hash PriorityQueue with hash_context for MergeError" {
 
 test "Histogram insert, and merge test number buckets in PWCH" {
     // Initialize a random number generator.
-    const seed: u64 = @bitCast(time.milliTimestamp());
+    const seed: u64 = @bitCast(tester.milliTimestamp());
     var prng = std.Random.DefaultPrng.init(seed);
     const random = prng.random();
 
@@ -721,7 +721,7 @@ test "Simple fixed values test of PWCH" {
 
 test "Fixed cluster number with random values for PWCH" {
     // Initialize a random number generator.
-    const seed: u64 = @bitCast(time.milliTimestamp());
+    const seed: u64 = @bitCast(tester.milliTimestamp());
     var prng = std.Random.DefaultPrng.init(seed);
     const random = prng.random();
 

--- a/src/lossy_compression/value_representation/histogram_representation.zig
+++ b/src/lossy_compression/value_representation/histogram_representation.zig
@@ -25,7 +25,6 @@ const std = @import("std");
 const mem = std.mem;
 const math = std.math;
 const testing = std.testing;
-const time = std.time;
 const ArrayList = std.ArrayList;
 const Allocator = mem.Allocator;
 

--- a/src/tersets.zig
+++ b/src/tersets.zig
@@ -68,6 +68,7 @@ pub const Error = error{
     ByteStreamError,
     UnsupportedMethod,
     OutOfMemory,
+    WriteFailed
 };
 
 /// The compression methods in TerseTS.

--- a/src/tersets.zig
+++ b/src/tersets.zig
@@ -68,7 +68,7 @@ pub const Error = error{
     ByteStreamError,
     UnsupportedMethod,
     OutOfMemory,
-    WriteFailed
+    WriteFailed,
 };
 
 /// The compression methods in TerseTS.

--- a/src/tester.zig
+++ b/src/tester.zig
@@ -67,7 +67,6 @@ const Allocator = std.mem.Allocator;
 const Error = std.mem.Allocator.Error;
 const Threaded = std.Io.Threaded;
 const math = std.math;
-const time = std.time;
 const testing = std.testing;
 const debug = std.debug;
 
@@ -1117,7 +1116,7 @@ pub fn resolveRandom(random_optional: ?Random) Random {
 
 /// Return a timestamp in milliseconds relative to UTC 1970-01-01.
 pub fn milliTimestamp() i64 {
-    var threaded: std.Io.Threaded = .init_single_threaded;
+    var threaded: Threaded = .init_single_threaded;
     const timestamp = Clock.real.now(threaded.io());
     threaded.deinit();
     return timestamp.toMilliseconds();

--- a/src/tester.zig
+++ b/src/tester.zig
@@ -61,9 +61,11 @@
 
 const std = @import("std");
 const ArrayList = std.ArrayList;
+const Clock = std.Io.Clock;
 const Random = std.Random;
 const Allocator = std.mem.Allocator;
 const Error = std.mem.Allocator.Error;
+const Threaded = std.Io.Threaded;
 const math = std.math;
 const time = std.time;
 const testing = std.testing;
@@ -1101,7 +1103,7 @@ pub fn generateNumberOfValues(random: Random) usize {
 /// pseudo-random number generator unless the seed is reset.
 pub fn getDefaultRandomGenerator() Random {
     if (default_seed == 0) {
-        default_seed = @bitCast(time.milliTimestamp());
+        default_seed = @bitCast(milliTimestamp());
         default_prng = std.Random.DefaultPrng.init(default_seed);
     }
     return default_prng.random();
@@ -1111,6 +1113,14 @@ pub fn getDefaultRandomGenerator() Random {
 /// this function returns the default `Random` instance.
 pub fn resolveRandom(random_optional: ?Random) Random {
     return random_optional orelse getDefaultRandomGenerator();
+}
+
+/// Return a timestamp in milliseconds relative to UTC 1970-01-01.
+pub fn milliTimestamp() i64 {
+    var threaded: std.Io.Threaded = .init_single_threaded;
+    const timestamp = Clock.real.now(threaded.io());
+    threaded.deinit();
+    return timestamp.toMilliseconds();
 }
 
 /// Adds noise to a given value based on `noise_scale`. This ensures that the noise is proportional

--- a/src/utilities/convex_hull.zig
+++ b/src/utilities/convex_hull.zig
@@ -659,7 +659,7 @@ test "Create incrementally convex hull with known result" {
 
 test "Create incrementally a convex hull with random elements" {
     const allocator = testing.allocator;
-    const seed: u64 = @bitCast(time.milliTimestamp());
+    const seed: u64 = @bitCast(tester.milliTimestamp());
     var rnd = std.Random.DefaultPrng.init(seed);
     const random = rnd.random();
 
@@ -901,7 +901,7 @@ test "Merge not-in-place convex hulls with random elements" {
 
 test "Merge in-place single element's convex hull with other convex hull" {
     const allocator = testing.allocator;
-    const seed: u64 = @bitCast(time.milliTimestamp());
+    const seed: u64 = @bitCast(tester.milliTimestamp());
     var rnd = std.Random.DefaultPrng.init(seed);
     const random = rnd.random();
 
@@ -924,7 +924,7 @@ test "Merge in-place single element's convex hull with other convex hull" {
 
 test "Merge not-in-place single element's convex hull with other convex hull" {
     const allocator = testing.allocator;
-    const seed: u64 = @bitCast(time.milliTimestamp());
+    const seed: u64 = @bitCast(tester.milliTimestamp());
     var rnd = std.Random.DefaultPrng.init(seed);
     const random = rnd.random();
 
@@ -950,7 +950,7 @@ test "Merge not-in-place single element's convex hull with other convex hull" {
 
 test "Merge in-place convex hull with single element's convex hull" {
     const allocator = testing.allocator;
-    const seed: u64 = @bitCast(time.milliTimestamp());
+    const seed: u64 = @bitCast(tester.milliTimestamp());
     var rnd = std.Random.DefaultPrng.init(seed);
     const random = rnd.random();
 
@@ -974,7 +974,7 @@ test "Merge in-place convex hull with single element's convex hull" {
 
 test "Merge not-in-place convex hull with single element's convex hull" {
     const allocator = testing.allocator;
-    const seed: u64 = @bitCast(time.milliTimestamp());
+    const seed: u64 = @bitCast(tester.milliTimestamp());
     var rnd = std.Random.DefaultPrng.init(seed);
     const random = rnd.random();
 
@@ -1001,7 +1001,7 @@ test "Merge not-in-place convex hull with single element's convex hull" {
 
 test "Merge not-in-place does not modify the convex hulls one and two" {
     const allocator = testing.allocator;
-    const seed: u64 = @bitCast(time.milliTimestamp());
+    const seed: u64 = @bitCast(tester.milliTimestamp());
     var rnd = std.Random.DefaultPrng.init(seed);
     const random = rnd.random();
 
@@ -1080,7 +1080,7 @@ test "Compute max error with known points and linear function" {
 
 test "Compute max error with random points and linear function" {
     const allocator = testing.allocator;
-    const seed: u64 = @bitCast(time.milliTimestamp());
+    const seed: u64 = @bitCast(tester.milliTimestamp());
     var rnd = std.Random.DefaultPrng.init(seed);
     const random = rnd.random();
 

--- a/src/utilities/convex_hull.zig
+++ b/src/utilities/convex_hull.zig
@@ -35,7 +35,6 @@ const ContinousPoint = shared.ContinousPoint;
 const Segment = shared.Segment;
 const LinearFunction = shared.LinearFunction;
 
-const time = std.time;
 const tester = @import("../tester.zig");
 
 /// Enum for the angle's `Turn` of three consecutive points A, B, and C. Essentially, it describes

--- a/src/utilities/hashed_priority_queue.zig
+++ b/src/utilities/hashed_priority_queue.zig
@@ -347,10 +347,12 @@ test "add and remove min key of custom struct in HashedPriorityQueue" {
     };
 
     const HashContext = struct {
-        pub fn hash(_: @This(), s: S) u64 {
+        const Self = @This();
+
+        pub fn hash(_: Self, s: S) u64 {
             return @as(u64, @bitCast(s.key));
         }
-        pub fn eql(_: @This(), s_one: S, s_two: S) bool {
+        pub fn eql(_: Self, s_one: S, s_two: S) bool {
             return s_one.key == s_two.key;
         }
     };
@@ -396,10 +398,12 @@ test "add, remove and element position for key of structs in HashedPriorityQueue
     };
 
     const HashContext = struct {
-        pub fn hash(_: @This(), s: S) u64 {
+        const Self = @This();
+
+        pub fn hash(_: Self, s: S) u64 {
             return @as(u64, @bitCast(s.key));
         }
-        pub fn eql(_: @This(), s_one: S, s_two: S) bool {
+        pub fn eql(_: Self, s_one: S, s_two: S) bool {
             return s_one.key == s_two.key;
         }
     };

--- a/src/utilities/hashed_priority_queue.zig
+++ b/src/utilities/hashed_priority_queue.zig
@@ -36,6 +36,7 @@ const expectError = testing.expectError;
 
 const tersets = @import("../tersets.zig");
 const Error = tersets.Error;
+const tester = @import("../tester.zig");
 
 /// A generic priority queue for storing generic data with hashed indexing for fast updates.
 /// Similar as with Zig's std.PriorityQueue, initialize with `init`. Provide `compareFn` that
@@ -274,7 +275,7 @@ test "add and remove min keys of simple values in HashedPriorityQueue" {
     defer list.deinit(allocator);
 
     // Initialize a random number generator.
-    const seed: u64 = @bitCast(time.milliTimestamp());
+    const seed: u64 = @bitCast(tester.milliTimestamp());
     var rnd = std.Random.DefaultPrng.init(seed);
 
     for (0..100) |_| {

--- a/src/utilities/hashed_priority_queue.zig
+++ b/src/utilities/hashed_priority_queue.zig
@@ -24,7 +24,6 @@
 const std = @import("std");
 const rand = std.Random;
 const math = std.math;
-const time = std.time;
 const Order = std.math.Order;
 const testing = std.testing;
 const HashMap = std.HashMap;

--- a/src/utilities/shared_functions.zig
+++ b/src/utilities/shared_functions.zig
@@ -16,7 +16,6 @@
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;
-const Io = std.Io;
 const math = std.math;
 const ArrayList = std.ArrayList;
 const Reader = std.Io.Reader;
@@ -27,7 +26,6 @@ const Error = tersets.Error;
 const testing = std.testing;
 
 const shared_structs = @import("shared_structs.zig");
-const BitWriter = shared_structs.BitWriter;
 
 /// Computes the Root-Mean-Squared-Errors (RMSE) for a segment of the `uncompressed_values`.
 /// This function calculates the error between the actual values and the predicted values
@@ -221,8 +219,7 @@ pub fn decodeZigZag(value: u64) i64 {
 /// encoded data. The function returns an `ArrayList(u8)` containing the encoded data, or an error
 /// if the input is unsupported or if memory allocation fails.
 pub fn encodeEliasGamma(allocator: Allocator, values: []const u64, encoded_values: *ArrayList(u8)) !void {
-    var bit_writer = try shared_structs.BitWriter.init(allocator);
-    defer bit_writer.deinit();
+    var bit_writer = try shared_structs.BitWriter.init(allocator, encoded_values);
 
     for (values) |value| {
         if (value == 0) {
@@ -239,7 +236,6 @@ pub fn encodeEliasGamma(allocator: Allocator, values: []const u64, encoded_value
         try bit_writer.writeBits(value, nbits + 1);
     }
     try bit_writer.flushBits();
-    try encoded_values.appendSlice(allocator, bit_writer.bytes.items);
 }
 
 /// Decodes an array of u8 `compressed_values` previously encoded using Elias Gamma encoding.

--- a/src/utilities/shared_functions.zig
+++ b/src/utilities/shared_functions.zig
@@ -221,8 +221,8 @@ pub fn decodeZigZag(value: u64) i64 {
 /// encoded data. The function returns an `ArrayList(u8)` containing the encoded data, or an error
 /// if the input is unsupported or if memory allocation fails.
 pub fn encodeEliasGamma(allocator: Allocator, values: []const u64, encoded_values: *ArrayList(u8)) !void {
-    var writer = Writer.Allocating.init(allocator);
-    var bit_writer = shared_structs.bitWriter(.big, writer.writer);
+    var bit_writer = try shared_structs.BitWriter(.big).init(allocator);
+    defer bit_writer.deinit();
 
     for (values) |value| {
         if (value == 0) {
@@ -239,7 +239,7 @@ pub fn encodeEliasGamma(allocator: Allocator, values: []const u64, encoded_value
         try bit_writer.writeBits(value, nbits + 1);
     }
     try bit_writer.flushBits();
-    try encoded_values.appendSlice(allocator, writer.toArrayList().items);
+    try encoded_values.appendSlice(allocator, bit_writer.bytes.items);
 }
 
 /// Decodes an array of u8 `compressed_values` previously encoded using Elias Gamma encoding.
@@ -254,7 +254,7 @@ pub fn decodeEliasGamma(
 ) !void {
     // Create bit reader over full byte slice.
     const reader = Reader.fixed(compressed_values);
-    var bit_reader = shared_structs.bitReader(.big, reader);
+    var bit_reader = shared_structs.BitReader(.big).init(reader);
 
     while (true) {
         // Count leading zeros.

--- a/src/utilities/shared_functions.zig
+++ b/src/utilities/shared_functions.zig
@@ -16,9 +16,11 @@
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;
-const io = std.io;
+const Io = std.Io;
 const math = std.math;
 const ArrayList = std.ArrayList;
+const Reader = std.Io.Reader;
+const Writer = std.Io.Writer;
 const tersets = @import("../tersets.zig");
 const tester = @import("../tester.zig");
 const Error = tersets.Error;
@@ -219,8 +221,8 @@ pub fn decodeZigZag(value: u64) i64 {
 /// encoded data. The function returns an `ArrayList(u8)` containing the encoded data, or an error
 /// if the input is unsupported or if memory allocation fails.
 pub fn encodeEliasGamma(allocator: Allocator, values: []const u64, encoded_values: *ArrayList(u8)) !void {
-    const writer = encoded_values.writer(allocator);
-    var bit_writer = shared_structs.bitWriter(.big, writer);
+    var writer = Writer.Allocating.init(allocator);
+    var bit_writer = shared_structs.bitWriter(.big, writer.writer);
 
     for (values) |value| {
         if (value == 0) {
@@ -237,6 +239,7 @@ pub fn encodeEliasGamma(allocator: Allocator, values: []const u64, encoded_value
         try bit_writer.writeBits(value, nbits + 1);
     }
     try bit_writer.flushBits();
+    try encoded_values.appendSlice(allocator, writer.toArrayList().items);
 }
 
 /// Decodes an array of u8 `compressed_values` previously encoded using Elias Gamma encoding.
@@ -250,8 +253,8 @@ pub fn decodeEliasGamma(
     decoded_values: *ArrayList(u64),
 ) !void {
     // Create bit reader over full byte slice.
-    var stream = io.fixedBufferStream(compressed_values);
-    var bit_reader = shared_structs.bitReader(.big, stream.reader());
+    const reader = Reader.fixed(compressed_values);
+    var bit_reader = shared_structs.bitReader(.big, reader);
 
     while (true) {
         // Count leading zeros.

--- a/src/utilities/shared_functions.zig
+++ b/src/utilities/shared_functions.zig
@@ -221,7 +221,7 @@ pub fn decodeZigZag(value: u64) i64 {
 /// encoded data. The function returns an `ArrayList(u8)` containing the encoded data, or an error
 /// if the input is unsupported or if memory allocation fails.
 pub fn encodeEliasGamma(allocator: Allocator, values: []const u64, encoded_values: *ArrayList(u8)) !void {
-    var bit_writer = try shared_structs.BitWriter(.big).init(allocator);
+    var bit_writer = try shared_structs.BitWriter.init(allocator);
     defer bit_writer.deinit();
 
     for (values) |value| {
@@ -254,7 +254,7 @@ pub fn decodeEliasGamma(
 ) !void {
     // Create bit reader over full byte slice.
     const reader = Reader.fixed(compressed_values);
-    var bit_reader = shared_structs.BitReader(.big).init(reader);
+    var bit_reader = shared_structs.BitReader.init(reader);
 
     while (true) {
         // Count leading zeros.

--- a/src/utilities/shared_structs.zig
+++ b/src/utilities/shared_structs.zig
@@ -91,273 +91,225 @@ pub fn HashMapf64(comptime value_type: type) type {
     return HashMap(f64, value_type, HashF64Context, std.hash_map.default_max_load_percentage);
 }
 
-/// Creates a `BitWriter` which allows for writing bits with `endian`. The code for `BitWriter` was
+/// Creates a `BitWriter` which allows for writing bits with Big Endian. The code for `BitWriter` was
 /// originally copied from Zig's MIT licensed standard library as suggested in GitHub PR 24614 since
 /// it was removed in Zig 0.15.1. The code has since been modified to simplify its use in TerseTS.
-pub fn BitWriter(comptime endian: std.builtin.Endian) type {
-    return struct {
-        allocator: Allocator,
-        bytes: ArrayList(u8),
-        bits: u8 = 0,
-        count: u4 = 0,
+pub const BitWriter = struct {
+    allocator: Allocator,
+    bytes: ArrayList(u8),
+    bits: u8 = 0,
+    count: u4 = 0,
 
-        const low_bit_mask = [9]u8{
-            0b00000000,
-            0b00000001,
-            0b00000011,
-            0b00000111,
-            0b00001111,
-            0b00011111,
-            0b00111111,
-            0b01111111,
-            0b11111111,
-        };
+    const Self = @This();
 
-        /// Initialize an empty `BitWriter`, which can be deinitialized  with `deinit`.
-        pub fn init(allocator: Allocator) !@This() {
-            return .{.allocator = allocator, .bytes = ArrayList(u8).empty, .bits = 0, .count = 0};
-        }
-
-        /// Write the specified number of bits to the writer from the least significant bits of
-        ///  the specified value. Bits will only be written to the writer when there
-        ///  are enough to fill a byte.
-        pub fn writeBits(self: *@This(), value: anytype, num: u16) !void {
-            const T = @TypeOf(value);
-            const UT = std.meta.Int(.unsigned, @bitSizeOf(T));
-            const U = if (@bitSizeOf(T) < 8) u8 else UT; //<u8 is a pain to work with
-
-            var in: U = @as(UT, @bitCast(value));
-            var in_count: u16 = num;
-
-            if (self.count > 0) {
-                //if we can't fill the buffer, add what we have
-                const bits_free = 8 - self.count;
-                if (num < bits_free) {
-                    self.addBits(@truncate(in), @intCast(num));
-                    return;
-                }
-
-                //finish filling the buffer and flush it
-                if (num == bits_free) {
-                    self.addBits(@truncate(in), @intCast(num));
-                    return self.flushBits();
-                }
-
-                switch (endian) {
-                    .big => {
-                        const bits = in >> @intCast(in_count - bits_free);
-                        self.addBits(@truncate(bits), bits_free);
-                    },
-                    .little => {
-                        self.addBits(@truncate(in), bits_free);
-                        in >>= @intCast(bits_free);
-                    },
-                }
-                in_count -= bits_free;
-                try self.flushBits();
-            }
-
-            //write full bytes while we can
-            const full_bytes_left = in_count / 8;
-            for (0..full_bytes_left) |_| {
-                switch (endian) {
-                    .big => {
-                        const bits = in >> @intCast(in_count - 8);
-                        try self.bytes.append(self.allocator, @truncate(bits));
-                    },
-                    .little => {
-                        try self.bytes.append(self.allocator, @truncate(in));
-                        if (U == u8) in = 0 else in >>= 8;
-                    },
-                }
-                in_count -= 8;
-            }
-
-            //save the remaining bits in the buffer
-            self.addBits(@truncate(in), @intCast(in_count));
-        }
-
-        //convenience function for adding bits to the buffer
-        //in the appropriate position based on endianess
-        fn addBits(self: *@This(), bits: u8, num: u4) void {
-            if (num == 8) self.bits = bits else switch (endian) {
-                .big => {
-                    self.bits <<= @intCast(num);
-                    self.bits |= bits & low_bit_mask[num];
-                },
-                .little => {
-                    const pos = bits << @intCast(self.count);
-                    self.bits |= pos;
-                },
-            }
-            self.count += num;
-        }
-
-        /// Flush any remaining bits to the writer, filling
-        /// unused bits with 0s.
-        pub fn flushBits(self: *@This()) !void {
-            if (self.count == 0) return;
-            if (endian == .big) self.bits <<= @intCast(8 - self.count);
-            try self.bytes.append(self.allocator, self.bits);
-            self.bits = 0;
-            self.count = 0;
-        }
-
-        /// Deinitiate the `BitWriter`.
-        pub fn deinit(self: *@This()) void {
-            self.bytes.deinit(self.allocator);
-        }
+    const low_bit_mask = [9]u8{
+        0b00000000,
+        0b00000001,
+        0b00000011,
+        0b00000111,
+        0b00001111,
+        0b00011111,
+        0b00111111,
+        0b01111111,
+        0b11111111,
     };
-}
 
-/// Creates a `BitReader` which allows for reading bits with `endian`. The code for `BitReader` was
-/// originally copied from Zig's MIT licensed standard library as suggested in GitHub PR 24614 since
-/// it was removed in Zig 0.15.1. The code has since been modified to simplify its use in TerseTS.
-pub fn BitReader(comptime endian: std.builtin.Endian) type {
-    return struct {
-        bytes: Reader,
-        bits: u8 = 0,
-        count: u4 = 0,
+    /// Initialize an empty `BitWriter`, which can be deinitialized  with `deinit`.
+    pub fn init(allocator: Allocator) !Self {
+        return .{.allocator = allocator, .bytes = ArrayList(u8).empty, .bits = 0, .count = 0};
+    }
 
-        const low_bit_mask = [9]u8{
-            0b00000000,
-            0b00000001,
-            0b00000011,
-            0b00000111,
-            0b00001111,
-            0b00011111,
-            0b00111111,
-            0b01111111,
-            0b11111111,
-        };
+    /// Write the specified number of bits to the writer from the least significant bits of
+    ///  the specified value. Bits will only be written to the writer when there
+    ///  are enough to fill a byte.
+    pub fn writeBits(self: *Self, value: anytype, num: u16) !void {
+        const T = @TypeOf(value);
+        const UT = std.meta.Int(.unsigned, @bitSizeOf(T));
+        const U = if (@bitSizeOf(T) < 8) u8 else UT;
 
-        fn Bits(comptime T: type) type {
-            return struct {
-                T,
-                u16,
-            };
-        }
+        const in: U = @as(UT, @bitCast(value));
+        var in_count: u16 = num;
 
-        fn initBits(comptime T: type, out: anytype, num: u16) Bits(T) {
-            const UT = std.meta.Int(.unsigned, @bitSizeOf(T));
-            return .{
-                @bitCast(@as(UT, @intCast(out))),
-                num,
-            };
-        }
-
-        /// Initialize an empty `BitReader`.
-        pub fn init(bytes: Reader) @This() {
-            return .{ .bytes = bytes };
-        }
-
-        /// Reads `bits` bits from the reader and returns a specified type
-        ///  containing them in the least significant end, returning an error if the
-        ///  specified number of bits could not be read.
-        pub fn readBitsNoEof(self: *@This(), comptime T: type, num: u16) !T {
-            const b, const c = try self.readBitsTuple(T, num);
-            if (c < num) return error.EndOfStream;
-            return b;
-        }
-
-        /// Reads `bits` bits from the reader and returns a specified type
-        ///  containing them in the least significant end. The number of bits successfully
-        ///  read is placed in `out_bits`, as reaching the end of the stream is not an error.
-        pub fn readBits(self: *@This(), comptime T: type, num: u16, out_bits: *u16) !T {
-            const b, const c = try self.readBitsTuple(T, num);
-            out_bits.* = c;
-            return b;
-        }
-
-        /// Reads `bits` bits from the reader and returns a tuple of the specified type
-        ///  containing them in the least significant end, and the number of bits successfully
-        ///  read. Reaching the end of the stream is not an error.
-        pub fn readBitsTuple(self: *@This(), comptime T: type, num: u16) !Bits(T) {
-            const UT = std.meta.Int(.unsigned, @bitSizeOf(T));
-            const U = if (@bitSizeOf(T) < 8) u8 else UT; //it is a pain to work with <u8
-
-            //dump any bits in our buffer first
-            if (num <= self.count) return initBits(T, self.removeBits(@intCast(num)), num);
-
-            var out_count: u16 = self.count;
-            var out: U = self.removeBits(self.count);
-
-            //grab all the full bytes we need and put their
-            //bits where they belong
-            const full_bytes_left = (num - out_count) / 8;
-
-            for (0..full_bytes_left) |_| {
-                const byte = self.bytes.takeByte() catch |err| switch (err) {
-                    error.EndOfStream => return initBits(T, out, out_count),
-                    else => |e| return e,
-                };
-
-                switch (endian) {
-                    .big => {
-                        if (U == u8) out = 0 else out <<= 8; //shifting u8 by 8 is illegal in Zig
-                        out |= byte;
-                    },
-                    .little => {
-                        const pos = @as(U, byte) << @intCast(out_count);
-                        out |= pos;
-                    },
-                }
-                out_count += 8;
+        if (self.count > 0) {
+            // if we can't fill the buffer, add what we have.
+            const bits_free = 8 - self.count;
+            if (num < bits_free) {
+                self.addBits(@truncate(in), @intCast(num));
+                return;
             }
 
-            const bits_left = num - out_count;
-            const keep = 8 - bits_left;
+            // Finish filling the buffer and flush it.
+            if (num == bits_free) {
+                self.addBits(@truncate(in), @intCast(num));
+                return self.flushBits();
+            }
 
-            if (bits_left == 0) return initBits(T, out, out_count);
+            const bits = in >> @intCast(in_count - bits_free);
+            self.addBits(@truncate(bits), bits_free);
 
-            const final_byte = self.bytes.takeByte() catch |err| switch (err) {
+            in_count -= bits_free;
+            try self.flushBits();
+        }
+
+        // Write full bytes while we can.
+        const full_bytes_left = in_count / 8;
+        for (0..full_bytes_left) |_| {
+            const bits = in >> @intCast(in_count - 8);
+            try self.bytes.append(self.allocator, @truncate(bits));
+            in_count -= 8;
+        }
+
+        // Save the remaining bits in the buffer.
+        self.addBits(@truncate(in), @intCast(in_count));
+    }
+
+    /// Convenience function for adding bits to the buffer.
+    fn addBits(self: *Self, bits: u8, num: u4) void {
+        if (num == 8) self.bits = bits else {
+            self.bits <<= @intCast(num);
+            self.bits |= bits & low_bit_mask[num];
+        }
+        self.count += num;
+    }
+
+    /// Flush any remaining bits to the writer, filling
+    /// unused bits with 0s.
+    pub fn flushBits(self: *Self) !void {
+        if (self.count == 0) return;
+        self.bits <<= @intCast(8 - self.count);
+        try self.bytes.append(self.allocator, self.bits);
+        self.bits = 0;
+        self.count = 0;
+    }
+
+    /// Deinitiate the `BitWriter`.
+    pub fn deinit(self: *Self) void {
+        self.bytes.deinit(self.allocator);
+    }
+};
+
+/// Creates a `BitReader` which allows for reading bits in Big Endian. The code for `BitReader` was
+/// originally copied from Zig's MIT licensed standard library as suggested in GitHub PR 24614 since
+/// it was removed in Zig 0.15.1. The code has since been modified to simplify its use in TerseTS.
+pub const BitReader = struct {
+    bytes: Reader,
+    bits: u8 = 0,
+    count: u4 = 0,
+
+    const Self = @This();
+
+    const low_bit_mask = [9]u8{
+        0b00000000,
+        0b00000001,
+        0b00000011,
+        0b00000111,
+        0b00001111,
+        0b00011111,
+        0b00111111,
+        0b01111111,
+        0b11111111,
+    };
+
+    fn Bits(comptime T: type) type {
+        return struct {
+            T,
+            u16,
+        };
+    }
+
+    fn initBits(comptime T: type, out: anytype, num: u16) Bits(T) {
+        const UT = std.meta.Int(.unsigned, @bitSizeOf(T));
+        return .{
+            @bitCast(@as(UT, @intCast(out))),
+            num,
+        };
+    }
+
+    /// Initialize an empty `BitReader`.
+    pub fn init(bytes: Reader) Self {
+        return .{ .bytes = bytes };
+    }
+
+    /// Reads `bits` bits from the reader and returns a specified type
+    ///  containing them in the least significant end, returning an error if the
+    ///  specified number of bits could not be read.
+    pub fn readBitsNoEof(self: *Self, comptime T: type, num: u16) !T {
+        const b, const c = try self.readBitsTuple(T, num);
+        if (c < num) return error.EndOfStream;
+        return b;
+    }
+
+    /// Reads `bits` bits from the reader and returns a specified type
+    /// containing them in the least significant end. The number of bits successfully
+    /// read is placed in `out_bits`, as reaching the end of the stream is not an error.
+    pub fn readBits(self: *Self, comptime T: type, num: u16, out_bits: *u16) !T {
+        const b, const c = try self.readBitsTuple(T, num);
+        out_bits.* = c;
+        return b;
+    }
+
+    /// Reads `bits` bits from the reader and returns a tuple of the specified type
+    /// containing them in the least significant end, and the number of bits successfully
+    /// read. Reaching the end of the stream is not an error.
+    pub fn readBitsTuple(self: *Self, comptime T: type, num: u16) !Bits(T) {
+        const UT = std.meta.Int(.unsigned, @bitSizeOf(T));
+        const U = if (@bitSizeOf(T) < 8) u8 else UT; //it is a pain to work with <u8
+
+        // Dump any bits in our buffer first.
+        if (num <= self.count) return initBits(T, self.removeBits(@intCast(num)), num);
+
+        var out_count: u16 = self.count;
+        var out: U = self.removeBits(self.count);
+
+        // Grab all the full bytes we need and put their bits where they belong.
+        const full_bytes_left = (num - out_count) / 8;
+
+        for (0..full_bytes_left) |_| {
+            const byte = self.bytes.takeByte() catch |err| switch (err) {
                 error.EndOfStream => return initBits(T, out, out_count),
                 else => |e| return e,
             };
 
-            switch (endian) {
-                .big => {
-                    out <<= @intCast(bits_left);
-                    out |= final_byte >> @intCast(keep);
-                    self.bits = final_byte & low_bit_mask[keep];
-                },
-                .little => {
-                    const pos = @as(U, final_byte & low_bit_mask[bits_left]) << @intCast(out_count);
-                    out |= pos;
-                    self.bits = final_byte >> @intCast(bits_left);
-                },
-            }
-
-            self.count = @intCast(keep);
-            return initBits(T, out, num);
+            if (U == u8) out = 0 else out <<= 8; //shifting u8 by 8 is illegal in Zig
+            out |= byte;
+            out_count += 8;
         }
 
-        //convenience function for removing bits from
-        //the appropriate part of the buffer based on
-        //endianess.
-        fn removeBits(self: *@This(), num: u4) u8 {
-            if (num == 8) {
-                self.count = 0;
-                return self.bits;
-            }
+        const bits_left = num - out_count;
+        const keep = 8 - bits_left;
 
-            const keep = self.count - num;
-            const bits = switch (endian) {
-                .big => self.bits >> @intCast(keep),
-                .little => self.bits & low_bit_mask[num],
-            };
-            switch (endian) {
-                .big => self.bits &= low_bit_mask[keep],
-                .little => self.bits >>= @intCast(num),
-            }
+        if (bits_left == 0) return initBits(T, out, out_count);
 
-            self.count = keep;
-            return bits;
-        }
+        const final_byte = self.bytes.takeByte() catch |err| switch (err) {
+            error.EndOfStream => return initBits(T, out, out_count),
+            else => |e| return e,
+        };
 
-        pub fn alignToByte(self: *@This()) void {
-            self.bits = 0;
+        out <<= @intCast(bits_left);
+        out |= final_byte >> @intCast(keep);
+        self.bits = final_byte & low_bit_mask[keep];
+
+        self.count = @intCast(keep);
+        return initBits(T, out, num);
+    }
+
+    // Convenience function for removing bits.
+    fn removeBits(self: *Self, num: u4) u8 {
+        if (num == 8) {
             self.count = 0;
+            return self.bits;
         }
-    };
-}
+
+        const keep = self.count - num;
+        const bits = self.bits >> @intCast(keep);
+        self.bits &= low_bit_mask[keep];
+
+        self.count = keep;
+        return bits;
+    }
+
+    pub fn alignToByte(self: *Self) void {
+        self.bits = 0;
+        self.count = 0;
+    }
+};

--- a/src/utilities/shared_structs.zig
+++ b/src/utilities/shared_structs.zig
@@ -20,6 +20,7 @@ const assert = std.debug.assert;
 const Allocator = mem.Allocator;
 const ArrayList = std.ArrayList;
 const HashMap = std.HashMap;
+const Reader = std.Io.Reader;
 
 /// Margin to adjust the error bound for numerical stability. Reducing the error bound by this
 /// margin ensures that all the elements of the decompressed time series are within the error bound
@@ -90,17 +91,13 @@ pub fn HashMapf64(comptime value_type: type) type {
     return HashMap(f64, value_type, HashF64Context, std.hash_map.default_max_load_percentage);
 }
 
-/// Creates a `BitWriter` which allows for writing bits to a `Writer`. `BitWriter` was removed in
-/// Zig 0.15.1. Thus, it was copied from Zig's standard library as suggested in GitHub PR 24614
-/// "Sorry, you will have to copy the old code into your application, or use a third party package."
-/// Zig's standard library is released under the MIT license. A new `BitWriter` was added for flate
-/// after Zig 0.15.1 was released, however, it currently only supports `u56` and not `u64`. Thus,
-/// the old `BitWriter` is used despite its use of the old `Writer` interface. To make it as
-/// explicit as possible that this code is copied from Zig's standard library, no attempt to make it
-/// consistent with TerseTS has been made.
-pub fn BitWriter(comptime endian: std.builtin.Endian, comptime Writer: type) type {
+/// Creates a `BitWriter` which allows for writing bits with `endian`. The code for `BitWriter` was
+/// originally copied from Zig's MIT licensed standard library as suggested in GitHub PR 24614 since
+/// it was removed in Zig 0.15.1. The code has since been modified to simplify its use in TerseTS.
+pub fn BitWriter(comptime endian: std.builtin.Endian) type {
     return struct {
-        writer: Writer,
+        allocator: Allocator,
+        bytes: ArrayList(u8),
         bits: u8 = 0,
         count: u4 = 0,
 
@@ -115,6 +112,11 @@ pub fn BitWriter(comptime endian: std.builtin.Endian, comptime Writer: type) typ
             0b01111111,
             0b11111111,
         };
+
+        /// Initialize an empty `BitWriter`, which can be deinitialized  with `deinit`.
+        pub fn init(allocator: Allocator) !@This() {
+            return .{.allocator = allocator, .bytes = ArrayList(u8).empty, .bits = 0, .count = 0};
+        }
 
         /// Write the specified number of bits to the writer from the least significant bits of
         ///  the specified value. Bits will only be written to the writer when there
@@ -161,10 +163,10 @@ pub fn BitWriter(comptime endian: std.builtin.Endian, comptime Writer: type) typ
                 switch (endian) {
                     .big => {
                         const bits = in >> @intCast(in_count - 8);
-                        try self.writer.writeByte(@truncate(bits));
+                        try self.bytes.append(self.allocator, @truncate(bits));
                     },
                     .little => {
-                        try self.writer.writeByte(@truncate(in));
+                        try self.bytes.append(self.allocator, @truncate(in));
                         if (U == u8) in = 0 else in >>= 8;
                     },
                 }
@@ -196,32 +198,24 @@ pub fn BitWriter(comptime endian: std.builtin.Endian, comptime Writer: type) typ
         pub fn flushBits(self: *@This()) !void {
             if (self.count == 0) return;
             if (endian == .big) self.bits <<= @intCast(8 - self.count);
-            try self.writer.writeByte(self.bits);
+            try self.bytes.append(self.allocator, self.bits);
             self.bits = 0;
             self.count = 0;
+        }
+
+        /// Deinitiate the `BitWriter`.
+        pub fn deinit(self: *@This()) void {
+            self.bytes.deinit(self.allocator);
         }
     };
 }
 
-/// Helper function to create a `BitWriter` with a specific type. `BitWriter` was removed in Zig
-/// 0.15.1. Thus, it was copied from Zig's standard library as suggested in GitHub PR 24614 "Sorry,
-/// you will have to copy the old code into your application, or use a third party package." Zig's
-/// standard library is released under the MIT license. To make it as explicit as possible that this
-/// code is copied from Zig's standard library, no attempt to make it consistent with TerseTS has
-/// been made.
-pub fn bitWriter(comptime endian: std.builtin.Endian, writer: anytype) BitWriter(endian, @TypeOf(writer)) {
-    return .{ .writer = writer };
-}
-
-/// Creates a `BitReader` which allows for reading bits from a `Reader`. `BitReader` was removed in
-/// Zig 0.15.1. Thus, it was copied from Zig's standard library as suggested in GitHub PR 24614
-/// "Sorry, you will have to copy the old code into your application, or use a third party package."
-/// Zig's standard library is released under the MIT license. A new `BitReader` has not yet been
-/// added to master. To make it as explicit as possible that this code is copied from Zig's standard
-/// library, no attempt to make it consistent with TerseTS has been made.
-pub fn BitReader(comptime endian: std.builtin.Endian, comptime Reader: type) type {
+/// Creates a `BitReader` which allows for reading bits with `endian`. The code for `BitReader` was
+/// originally copied from Zig's MIT licensed standard library as suggested in GitHub PR 24614 since
+/// it was removed in Zig 0.15.1. The code has since been modified to simplify its use in TerseTS.
+pub fn BitReader(comptime endian: std.builtin.Endian) type {
     return struct {
-        reader: Reader,
+        bytes: Reader,
         bits: u8 = 0,
         count: u4 = 0,
 
@@ -250,6 +244,11 @@ pub fn BitReader(comptime endian: std.builtin.Endian, comptime Reader: type) typ
                 @bitCast(@as(UT, @intCast(out))),
                 num,
             };
+        }
+
+        /// Initialize an empty `BitReader`.
+        pub fn init(bytes: Reader) @This() {
+            return .{ .bytes = bytes };
         }
 
         /// Reads `bits` bits from the reader and returns a specified type
@@ -288,7 +287,7 @@ pub fn BitReader(comptime endian: std.builtin.Endian, comptime Reader: type) typ
             const full_bytes_left = (num - out_count) / 8;
 
             for (0..full_bytes_left) |_| {
-                const byte = self.reader.takeByte() catch |err| switch (err) {
+                const byte = self.bytes.takeByte() catch |err| switch (err) {
                     error.EndOfStream => return initBits(T, out, out_count),
                     else => |e| return e,
                 };
@@ -311,7 +310,7 @@ pub fn BitReader(comptime endian: std.builtin.Endian, comptime Reader: type) typ
 
             if (bits_left == 0) return initBits(T, out, out_count);
 
-            const final_byte = self.reader.takeByte() catch |err| switch (err) {
+            const final_byte = self.bytes.takeByte() catch |err| switch (err) {
                 error.EndOfStream => return initBits(T, out, out_count),
                 else => |e| return e,
             };
@@ -361,14 +360,4 @@ pub fn BitReader(comptime endian: std.builtin.Endian, comptime Reader: type) typ
             self.count = 0;
         }
     };
-}
-
-/// Helper function to create a `BitReader` with a specific type. `BitReader` was removed in Zig
-/// 0.15.1. Thus, it was copied from Zig's standard library as suggested in GitHub PR 24614 "Sorry,
-/// you will have to copy the old code into your application, or use a third party package." Zig's
-/// standard library is released under the MIT license. To make it as explicit as possible that this
-/// code is copied from Zig's standard library, no attempt to make it consistent with TerseTS has
-/// been made.
-pub fn bitReader(comptime endian: std.builtin.Endian, reader: anytype) BitReader(endian, @TypeOf(reader)) {
-    return .{ .reader = reader };
 }

--- a/src/utilities/shared_structs.zig
+++ b/src/utilities/shared_structs.zig
@@ -116,7 +116,7 @@ pub const BitWriter = struct {
 
     /// Initialize an empty `BitWriter`, which can be deinitialized  with `deinit`.
     pub fn init(allocator: Allocator) !Self {
-        return .{.allocator = allocator, .bytes = ArrayList(u8).empty, .bits = 0, .count = 0};
+        return .{ .allocator = allocator, .bytes = ArrayList(u8).empty, .bits = 0, .count = 0 };
     }
 
     /// Write the specified number of bits to the writer from the least significant bits of

--- a/src/utilities/shared_structs.zig
+++ b/src/utilities/shared_structs.zig
@@ -96,7 +96,7 @@ pub fn HashMapf64(comptime value_type: type) type {
 /// it was removed in Zig 0.15.1. The code has since been modified to simplify its use in TerseTS.
 pub const BitWriter = struct {
     allocator: Allocator,
-    bytes: ArrayList(u8),
+    bytes: *ArrayList(u8),
     bits: u8 = 0,
     count: u4 = 0,
 
@@ -114,14 +114,13 @@ pub const BitWriter = struct {
         0b11111111,
     };
 
-    /// Initialize an empty `BitWriter`, which can be deinitialized  with `deinit`.
-    pub fn init(allocator: Allocator) !Self {
-        return .{ .allocator = allocator, .bytes = ArrayList(u8).empty, .bits = 0, .count = 0 };
+    /// Initialize an empty `BitWriter`.
+    pub fn init(allocator: Allocator, bytes: *ArrayList(u8)) !Self {
+        return .{ .allocator = allocator, .bytes = bytes, .bits = 0, .count = 0 };
     }
 
-    /// Write the specified number of bits to the writer from the least significant bits of
-    ///  the specified value. Bits will only be written to the writer when there
-    ///  are enough to fill a byte.
+    /// Write the specified number of bits to the writer from the least significant bits of the
+    /// input `value`. Bits will only be written to the writer when there are enough to fill a byte.
     pub fn writeBits(self: *Self, value: anytype, num: u16) !void {
         const T = @TypeOf(value);
         const UT = std.meta.Int(.unsigned, @bitSizeOf(T));
@@ -180,11 +179,6 @@ pub const BitWriter = struct {
         try self.bytes.append(self.allocator, self.bits);
         self.bits = 0;
         self.count = 0;
-    }
-
-    /// Deinitiate the `BitWriter`.
-    pub fn deinit(self: *Self) void {
-        self.bytes.deinit(self.allocator);
     }
 };
 

--- a/src/utilities/shared_structs.zig
+++ b/src/utilities/shared_structs.zig
@@ -288,7 +288,7 @@ pub fn BitReader(comptime endian: std.builtin.Endian, comptime Reader: type) typ
             const full_bytes_left = (num - out_count) / 8;
 
             for (0..full_bytes_left) |_| {
-                const byte = self.reader.readByte() catch |err| switch (err) {
+                const byte = self.reader.takeByte() catch |err| switch (err) {
                     error.EndOfStream => return initBits(T, out, out_count),
                     else => |e| return e,
                 };
@@ -311,7 +311,7 @@ pub fn BitReader(comptime endian: std.builtin.Endian, comptime Reader: type) typ
 
             if (bits_left == 0) return initBits(T, out, out_count);
 
-            const final_byte = self.reader.readByte() catch |err| switch (err) {
+            const final_byte = self.reader.takeByte() catch |err| switch (err) {
                 error.EndOfStream => return initBits(T, out, out_count),
                 else => |e| return e,
             };


### PR DESCRIPTION
### Summary
This PR updates the version of Zig used for TerseTS to Zig 0.16.0, which is currently the latest stable version of Zig released. This is to make the installation instructions correct again, as the first step is "_1. Download the latest version of [Zig](https://ziglang.org/)_". Most of the changes to the source code were caused by the "I/O as an Interface" changes in [Zig 0.16.0](https://ziglang.org/download/0.16.0/release-notes.html#IO-as-an-Interface). To reduce the impact of the changes to `Reader` and `Writer` that started with [writergate](https://ziglang.org/download/0.15.1/release-notes.html#Writergate), `BitReader` and `BitWriter` are now just simple `structs` that use Big Endian. As that is all we currently require for TerseTS, I saw no reason to continue maintaining the more complex versions we copied from Zig's standard library after they were removed in Zig 0.15.1. Please review the changes I have made to them extra carefully to ensure I have not introduced subtle bugs.