### PR TITLE
Adding zig 0.17 compilation fixes

### DIFF
--- a/src/lossy_compression/functional_approximation/sim_piece.zig
+++ b/src/lossy_compression/functional_approximation/sim_piece.zig
@@ -167,14 +167,15 @@ pub fn decompress(
         current_index = next_metadata_start_index;
     }
 
-    const current_metadata = segments_metadata.getLast();
-    try decompressSegment(
-        allocator,
-        current_metadata,
-        current_index,
-        last_index,
-        decompressed_values,
-    );
+    if (segments_metadata.getLast()) |current_metadata| {
+        try decompressSegment(
+            allocator,
+            current_metadata,
+            current_index,
+            last_index,
+            decompressed_values,
+        );
+    }
 }
 
 /// Extracts `indices` and `coefficients` from SimPiece's `compressed_values`.

--- a/src/utilities/shared_structs.zig
+++ b/src/utilities/shared_structs.zig
@@ -123,7 +123,7 @@ pub const BitWriter = struct {
     /// input `value`. Bits will only be written to the writer when there are enough to fill a byte.
     pub fn writeBits(self: *Self, value: anytype, num: u16) !void {
         const T = @TypeOf(value);
-        const UT = std.meta.Int(.unsigned, @bitSizeOf(T));
+        const UT = @Int(.unsigned, @bitSizeOf(T));
         const U = if (@bitSizeOf(T) < 8) u8 else UT;
 
         const in: U = @as(UT, @bitCast(value));
@@ -212,7 +212,7 @@ pub const BitReader = struct {
     }
 
     fn initBits(comptime T: type, out: anytype, num: u16) Bits(T) {
-        const UT = std.meta.Int(.unsigned, @bitSizeOf(T));
+        const UT = @Int(.unsigned, @bitSizeOf(T));
         return .{
             @bitCast(@as(UT, @intCast(out))),
             num,
@@ -246,7 +246,7 @@ pub const BitReader = struct {
     /// containing them in the least significant end, and the number of bits successfully
     /// read. Reaching the end of the stream is not an error.
     pub fn readBitsTuple(self: *Self, comptime T: type, num: u16) !Bits(T) {
-        const UT = std.meta.Int(.unsigned, @bitSizeOf(T));
+        const UT = @Int(.unsigned, @bitSizeOf(T));
         const U = if (@bitSizeOf(T) < 8) u8 else UT; //it is a pain to work with <u8
 
         // Dump any bits in our buffer first.


### PR DESCRIPTION
### Summary

This PR fixes minor compilation issues that block compiling tersets using 0.17 (dev master) version of zig.

getLast change breaks 0.16 compatibility.

### Files Added/Modified

- sim piece - getLast now returns optional that needs to be unwrapped
- shared structs - use @Int instead of relying on meta.Int which has been removed 

### Testing

- nothing applies

