### PR TITLE
Add Indexed Priority Queue to improve execution time

### DIFF
--- a/src/lossy_compression/functional_approximation/poor_mans_compression.zig
+++ b/src/lossy_compression/functional_approximation/poor_mans_compression.zig
@@ -100,7 +100,10 @@ pub fn compressMidrange(
         index += 1;
     }
 
-    const compressed_value: f64 = @floatCast((maximum + minimum) / 2);
+    const compressed_value: f64 = if (error_bound == 0)
+        @floatCast(maximum)
+    else
+        @floatCast((maximum + minimum) / 2);
     try shared_functions.appendValueAndIndexToArrayList(
         allocator,
         compressed_value,

--- a/src/lossy_compression/line_simplification/bottom_up.zig
+++ b/src/lossy_compression/line_simplification/bottom_up.zig
@@ -23,24 +23,16 @@
 const std = @import("std");
 const mem = std.mem;
 const math = std.math;
-const time = std.time;
 const ArrayList = std.ArrayList;
 const Allocator = mem.Allocator;
 
 const tersets = @import("../../tersets.zig");
 const configuration = @import("../../configuration.zig");
-const Method = tersets.Method;
 const Error = tersets.Error;
 
-const HashedPriorityQueue = @import(
-    "../../utilities/hashed_priority_queue.zig",
-).HashedPriorityQueue;
+const IndexedPriorityQueue = @import("../../utilities/indexed_priority_queue.zig").IndexedPriorityQueue;
 
-const shared_structs = @import("../../utilities/shared_structs.zig");
 const shared_functions = @import("../../utilities/shared_functions.zig");
-
-const DiscretePoint = shared_structs.DiscretePoint;
-const LinearFunction = shared_structs.LinearFunction;
 
 const tester = @import("../../tester.zig");
 const extractors = @import("../../utilities/extractors.zig");
@@ -52,7 +44,7 @@ const testing = std.testing;
 /// This algorithm iteratively merges points to minimize the sum of squared errors,
 /// ensuring that the resulting compressed sequence stays within the specified `error_bound`.
 /// The function writes the simplified sequence to the `compressed_values`. The `allocator`
-/// is used to allocate memory for the HashedPriorityQueue used in the implementation and
+/// is used to allocate memory for the IndexedPriorityQueue used in the implementation and
 /// the `method_configuration` parser. The `method_configuration` is expected to be of
 /// `AggregateError` type otherwise an `InvalidConfiguration` error is return. If any other
 /// error occurs during the execution of the method, it is returned.
@@ -78,104 +70,112 @@ pub fn compress(
         return;
     }
 
-    // Initialize a hashed priority queue to store the effective area of triangles formed by every
-    // sequence of three consecutive points. The priority is determined by the area.
-    var heap = try HashedPriorityQueue(
-        SegmentMergeCost,
-        void,
-        compareSegmentMergeCost,
-        SegmentMergeCostHashContext,
-    ).init(allocator, {});
+    const segment_count = (uncompressed_values.len + 1) / 2;
+
+    // Initialize an indexed priority queue to store the cost of merging each segment with the
+    // segment to its right. Segment IDs are dense and stable for the whole compression run.
+    var heap = try IndexedPriorityQueue(f64, compareMergeCost).init(allocator, segment_count);
     defer heap.deinit();
 
-    // Compute all pairwise merging cost of the segments.
-    try buildInitialPairwiseSegmentCost(&heap, uncompressed_values);
+    const costs = try allocator.alloc(f64, segment_count);
+    defer allocator.free(costs);
+    const left_segments = try allocator.alloc(usize, segment_count);
+    defer allocator.free(left_segments);
+    const right_segments = try allocator.alloc(usize, segment_count);
+    defer allocator.free(right_segments);
+    const segment_starts = try allocator.alloc(usize, segment_count);
+    defer allocator.free(segment_starts);
+    const segment_ends = try allocator.alloc(usize, segment_count);
+    defer allocator.free(segment_ends);
 
-    // Placeholder for the segment cost to be used in the loop to search for neighboring segments.
-    // During the merging process, we keep track of neighboring segments: the "left segment" is
-    // the segment immediately before the current one, and the "right segment" is the segment
-    // immediately after. These relationships are maintained using the `left_seg` and `right_seg`
-    // fields in the `SegmentMergeCost` struct.
-    var placeholder_segment_cost: SegmentMergeCost = .{
-        .index = undefined,
-        .cost = undefined,
-        .left_seg = undefined,
-        .right_seg = undefined,
-        .seg_start = undefined,
-        .seg_end = undefined,
-    };
+    // Compute all pairwise merging costs of the segments.
+    try buildInitialPairwiseSegmentCost(
+        &heap,
+        costs,
+        left_segments,
+        right_segments,
+        segment_starts,
+        segment_ends,
+        uncompressed_values,
+    );
 
-    while (heap.len > 2) {
+    while (heap.count() > 2) {
         // Peek into the segment with the lowest cost.
-        const min_segment: SegmentMergeCost = try heap.peek();
+        const min_segment = try heap.peek();
+        const min_segment_index = min_segment.index;
 
         // Check if the cost is within the error bound.
-        if (min_segment.cost > error_bound) {
+        if (min_segment.priority > error_bound) {
             break;
         }
 
-        // Now is safe to pop the point from the heap.
+        // Now is safe to pop the segment from the heap.
         _ = try heap.pop();
 
-        // Update the index of the placeholder segment to the right segment of the current minimum segment.
-        placeholder_segment_cost.index = min_segment.right_seg;
-
-        // Retrieve the right segment from the heap using its index.
-        var right_seg: SegmentMergeCost = try heap.get(try heap.getIndex(placeholder_segment_cost));
+        const right_segment_index = right_segments[min_segment_index];
 
         // Update the start of the right segment to include the start of the merged segment.
-        right_seg.seg_start = min_segment.seg_start;
+        segment_starts[right_segment_index] = segment_starts[min_segment_index];
 
         // If the current minimum segment is not the first segment, update the left segment.
-        if (min_segment.seg_start != 0) {
-            // Update the index of the placeholder segment to the left segment of the current minimum segment.
-            placeholder_segment_cost.index = min_segment.left_seg;
+        if (segment_starts[min_segment_index] != 0) {
+            const left_segment_index = left_segments[min_segment_index];
 
-            // Retrieve the left segment from the heap using its index.
-            var left_seg: SegmentMergeCost = try heap.get(try heap.getIndex(placeholder_segment_cost));
-
-            // Update the right segment's left neighbor to the left segment's index.
-            right_seg.left_seg = left_seg.index;
-
-            // Update the left segment's right neighbor to the right segment's index.
-            left_seg.right_seg = right_seg.index;
+            // Update the neighboring segment links to bypass the removed segment.
+            left_segments[right_segment_index] = left_segment_index;
+            right_segments[left_segment_index] = right_segment_index;
 
             // Compute the merge cost of merging the left and right segments.
-            const merge_cost = try mergeCost(uncompressed_values, left_seg, right_seg);
-
-            // Update the cost of the left segment with the computed merge cost.
-            left_seg.cost = merge_cost;
+            costs[left_segment_index] = try mergeCostFromState(
+                uncompressed_values,
+                segment_starts,
+                segment_ends,
+                left_segment_index,
+                right_segment_index,
+            );
 
             // Update the left segment in the heap.
-            try heap.update(left_seg, left_seg);
+            try heap.update(left_segment_index, costs[left_segment_index]);
         }
 
         // If the right segment is not the last segment, update its merge cost with its right neighbor.
-        if (right_seg.seg_end != uncompressed_values.len - 1) {
-            // Update the index of the placeholder segment to the right neighbor of the right segment.
-            placeholder_segment_cost.index = right_seg.right_seg;
-
-            // Retrieve the right neighbor of the right segment from the heap.
-            const right_to_right_seg = try heap.get(try heap.getIndex(placeholder_segment_cost));
-
+        if (segment_ends[right_segment_index] != uncompressed_values.len - 1) {
             // Compute the merge cost of merging the right segment with its right neighbor.
-            const merge_cost = try mergeCost(uncompressed_values, right_seg, right_to_right_seg);
-
-            // Update the cost of the right segment with the computed merge cost.
-            right_seg.cost = merge_cost;
+            costs[right_segment_index] = try mergeCostFromState(
+                uncompressed_values,
+                segment_starts,
+                segment_ends,
+                right_segment_index,
+                right_segments[right_segment_index],
+            );
         }
 
         // Update the right segment in the heap.
-        try heap.update(right_seg, right_seg);
+        try heap.update(right_segment_index, costs[right_segment_index]);
     }
 
     // Sort remaining points by original index to preserve order.
-    mem.sort(SegmentMergeCost, heap.items[0..heap.len], {}, SegmentMergeCost.firstThan);
+    var remaining_segments = ArrayList(SegmentMergeCost).empty;
+    defer remaining_segments.deinit(allocator);
+    try remaining_segments.ensureTotalCapacity(allocator, heap.count());
+
+    for (0..segment_count) |segment_index| {
+        if (!heap.contains(segment_index)) continue;
+        try remaining_segments.append(allocator, .{
+            .index = segment_index,
+            .cost = costs[segment_index],
+            .left_seg = left_segments[segment_index],
+            .right_seg = right_segments[segment_index],
+            .seg_start = segment_starts[segment_index],
+            .seg_end = segment_ends[segment_index],
+        });
+    }
+    mem.sort(SegmentMergeCost, remaining_segments.items, {}, SegmentMergeCost.firstThan);
 
     // Output compressed series: (seg_start, index, end_value) pairs.
-    for (0..heap.len) |index| {
-        const seg_start = heap.items[index].seg_start;
-        const seg_end = heap.items[index].seg_end;
+    for (remaining_segments.items) |segment| {
+        const seg_start = segment.seg_start;
+        const seg_end = segment.seg_end;
         // Append the start value, the end index, and the end value to the compressed representation.
         try shared_functions.appendValue(allocator, f64, uncompressed_values[seg_start], compressed_values);
         try shared_functions.appendValue(allocator, f64, uncompressed_values[seg_end], compressed_values);
@@ -310,102 +310,59 @@ const SegmentMergeCost = struct {
     }
 };
 
-/// `SegmentMergeCostHashContext` provides context for hashing and comparing `SegmentMergeCost` items for use
-/// in `HashMap`. It defines how `SegmentMergeCost` are hashed and compared for equality.
-const SegmentMergeCostHashContext = struct {
-    /// Hashes the `index: usize` by bitcasting it to `u64`.
-    pub fn hash(_: SegmentMergeCostHashContext, seg_merge_cost: SegmentMergeCost) u64 {
-        return @as(u64, @intCast(seg_merge_cost.index));
-    }
-    /// Compares two `index` for equality.
-    pub fn eql(
-        _: SegmentMergeCostHashContext,
-        seg_merge_error_one: SegmentMergeCost,
-        seg_merge_error_two: SegmentMergeCost,
-    ) bool {
-        return seg_merge_error_one.index == seg_merge_error_two.index;
-    }
-};
-
-/// Comparison function for the `HashedPriorityQueue`. It compares merge cost between two segments.
-fn compareSegmentMergeCost(_: void, seg_1: SegmentMergeCost, seg_2: SegmentMergeCost) math.Order {
-    if (seg_1.cost == seg_2.cost)
-        return math.Order.eq;
-    return math.order(seg_1.cost, seg_2.cost);
+/// Comparison function for the `IndexedPriorityQueue`. It compares merge costs between two segments.
+fn compareMergeCost(cost_1: f64, cost_2: f64) math.Order {
+    return math.order(cost_1, cost_2);
 }
 
 /// Build initial pair-wise segments costs (two points per segment if possible).
 fn buildInitialPairwiseSegmentCost(
-    heap: *HashedPriorityQueue(
-        SegmentMergeCost,
-        void,
-        compareSegmentMergeCost,
-        SegmentMergeCostHashContext,
-    ),
+    heap: *IndexedPriorityQueue(f64, compareMergeCost),
+    costs: []f64,
+    left_segments: []usize,
+    right_segments: []usize,
+    segment_starts: []usize,
+    segment_ends: []usize,
     uncompressed_values: []const f64,
 ) Error!void {
-    var seg_id: usize = 1;
-    var seg_start: usize = 2;
-
     // We need to create a segment for every two points in the uncompressed values.
     // The first segment is always the first two points.
     // The second segment is the next two points, and so on.
-    var previous_seg = SegmentMergeCost{
-        .index = 0,
-        .cost = math.inf(f64),
-        .left_seg = 0,
-        .right_seg = 1,
-        .seg_start = 0,
-        .seg_end = 1,
-    };
-
-    while (seg_start < uncompressed_values.len) : (seg_start += 2) {
+    for (0..costs.len) |segment_index| {
+        const seg_start = segment_index * 2;
         const seg_end: usize = if (seg_start + 1 < uncompressed_values.len) seg_start + 1 else seg_start;
 
-        const current_seg = SegmentMergeCost{
-            .index = seg_id,
-            .cost = math.inf(f64),
-            .left_seg = seg_id - 1,
-            .right_seg = seg_id + 1,
-            .seg_start = seg_start,
-            .seg_end = seg_end,
-        };
-
-        // Compute the merge cost of merging the previous and current segments.
-        const merge_cost = try mergeCost(uncompressed_values, previous_seg, current_seg);
-        previous_seg.cost = merge_cost;
-        try heap.add(previous_seg);
-
-        seg_id += 1;
-        previous_seg = current_seg;
+        left_segments[segment_index] = if (segment_index == 0) 0 else segment_index - 1;
+        right_segments[segment_index] = segment_index + 1;
+        segment_starts[segment_index] = seg_start;
+        segment_ends[segment_index] = seg_end;
+        costs[segment_index] = math.inf(f64);
     }
 
-    // Inserts the previous segment, which is likely the last segment in the sequence.
-    // In the bottom-up line simplification algorithm, the last segment cannot be merged
-    // with any segment to its right, as there are no further segments. Therefore, it is
-    // added with an infinite cost to indicate that no further merging is possible.
-    try heap.add(previous_seg);
-
-    // If the last segment is not a pair, we need to add it to the heap.
-    if (seg_start < uncompressed_values.len) {
-        var last_seg = SegmentMergeCost{
-            .index = seg_id,
-            .cost = math.inf(f64),
-            .left_seg = seg_id - 1,
-            .right_seg = seg_id + 1,
-            .seg_start = seg_start,
-            .seg_end = seg_start,
-        };
-        const merge_cost = try mergeCost(uncompressed_values, previous_seg, last_seg);
-        last_seg.cost = merge_cost;
-        try heap.add(last_seg);
+    for (0..costs.len) |segment_index| {
+        if (segment_index + 1 < costs.len) {
+            costs[segment_index] = try mergeCostFromState(
+                uncompressed_values,
+                segment_starts,
+                segment_ends,
+                segment_index,
+                segment_index + 1,
+            );
+        }
+        try heap.add(segment_index, costs[segment_index]);
     }
 }
 
-/// Incremental cost of merging the neighbouring segments `seg_one` and `seg_two`.
-fn mergeCost(uncompressed_values: []const f64, seg_one: SegmentMergeCost, seg_two: SegmentMergeCost) !f64 {
-    const merged_start = @min(seg_one.seg_start, seg_two.seg_start);
-    const merged_end = @max(seg_one.seg_end, seg_two.seg_end);
+/// Incremental cost of merging the neighbouring segments identified by dense segment IDs.
+fn mergeCostFromState(
+    uncompressed_values: []const f64,
+    segment_starts: []const usize,
+    segment_ends: []const usize,
+    segment_one: usize,
+    segment_two: usize,
+) !f64 {
+    const merged_start = @min(segment_starts[segment_one], segment_starts[segment_two]);
+    const merged_end = @max(segment_ends[segment_one], segment_ends[segment_two]);
     return try shared_functions.computeRMSE(uncompressed_values, merged_start, merged_end);
 }
 

--- a/src/lossy_compression/line_simplification/bottom_up.zig
+++ b/src/lossy_compression/line_simplification/bottom_up.zig
@@ -154,7 +154,7 @@ pub fn compress(
         try heap.update(right_segment_index, costs[right_segment_index]);
     }
 
-    // Sort remaining points by original index to preserve order.
+    // Sort remaining segments by original index to preserve order.
     var remaining_segments = ArrayList(SegmentMergeCost).empty;
     defer remaining_segments.deinit(allocator);
     try remaining_segments.ensureTotalCapacity(allocator, heap.count());

--- a/src/lossy_compression/line_simplification/visvalingam_whyatt.zig
+++ b/src/lossy_compression/line_simplification/visvalingam_whyatt.zig
@@ -29,10 +29,6 @@ const configuration = @import("../../configuration.zig");
 const Method = tersets.Method;
 const Error = tersets.Error;
 
-const HashedPriorityQueue = @import(
-    "../../utilities/hashed_priority_queue.zig",
-).HashedPriorityQueue;
-
 const shared_structs = @import("../../utilities/shared_structs.zig");
 const shared_functions = @import("../../utilities/shared_functions.zig");
 
@@ -44,11 +40,12 @@ const tester = @import("../../tester.zig");
 
 const extractors = @import("../../utilities/extractors.zig");
 const rebuilders = @import("../../utilities/rebuilders.zig");
+const IndexedPriorityQueue = @import("../../utilities/indexed_priority_queue.zig").IndexedPriorityQueue;
 
 /// Compress `uncompressed_values` using "Visvalingam-Whyatt" simplification algorithm by keeping
 /// points whose effective area is greater than the `error_bound`. The function writes the result
-/// to `compressed_values`. The `allocator` is used to allocate memory for the HashedPriorityQueue
-/// used in the implementation and the `method_configuration` parser. The `method_configuration`
+/// to `compressed_values`. The `allocator` is used to allocate memory for the temporary
+/// simplification state and the `method_configuration` parser. The `method_configuration`
 /// is expected to be of `AreaUnderCurveError` type otherwise an `InvalidConfiguration` error is return.
 /// If any other error occurs during the execution of the method, it is returned.
 pub fn compress(
@@ -73,102 +70,70 @@ pub fn compress(
         return;
     }
 
-    // Initialize a hashed priority queue to store the effective area of triangles formed by every
-    // sequence of three consecutive points. The priority is determined by the area.
-    var heap = try HashedPriorityQueue(
-        PointArea,
-        void,
-        comparePointArea,
-        PointAreaHashContext,
-    ).init(allocator, {});
+    const point_count = uncompressed_values.len;
+
+    var heap = try IndexedPriorityQueue(f64, compareArea).init(allocator, point_count);
     defer heap.deinit();
 
-    // First point cannot be removed. Thus, the area is set to inf.
-    try heap.add(PointArea{
-        .index = 0,
-        .area = math.inf(f64),
-        .left_point = 0,
-        .right_point = 1,
-    });
+    const left_points = try allocator.alloc(usize, point_count);
+    defer allocator.free(left_points);
+    const right_points = try allocator.alloc(usize, point_count);
+    defer allocator.free(right_points);
 
-    // Calculate initial areas.
-    for (1..uncompressed_values.len - 1) |i| {
-        try heap.add(PointArea{
-            .index = i,
-            .area = calculateArea(
-                DiscretePoint{ .index = i - 1, .value = uncompressed_values[i - 1] },
-                DiscretePoint{ .index = i, .value = uncompressed_values[i] },
-                DiscretePoint{ .index = i + 1, .value = uncompressed_values[i + 1] },
-            ),
-            .left_point = i - 1,
-            .right_point = i + 1,
-        });
+    for (0..point_count) |i| {
+        left_points[i] = if (i == 0) 0 else i - 1;
+        right_points[i] = i + 1;
+        const area = if (i == 0 or i == point_count - 1)
+            math.inf(f64)
+        else
+            calculateAreaFromValues(uncompressed_values, i - 1, i, i + 1);
+        try heap.add(i, area);
     }
 
-    // Last point cannot be removed. Thus the area is set to inf.
-    try heap.add(PointArea{
-        .index = uncompressed_values.len - 1,
-        .area = math.inf(f64),
-        .left_point = uncompressed_values.len - 2,
-        .right_point = uncompressed_values.len,
-    });
-
-    // Placeholder for the point area to be used in the loop to search for neighboring points.
-    var placeholder_point_area: PointArea = .{
-        .index = 0,
-        .area = 0,
-        .left_point = 0,
-        .right_point = 0,
-    };
+    var remaining_points = point_count;
 
     // Main simplification loop.
-    while (heap.items.len > 2) {
+    while (heap.count() > 2) {
         // Get the point with the smallest area.
-        const min_point: PointArea = try heap.peek();
+        const min_point = try heap.peek();
 
         // The area is greater than the error bound.
-        if (min_point.area >= error_bound) {
+        if (min_point.priority >= error_bound) {
             break;
         }
 
         // Now is safe to remove the point with the smallest area.
         _ = try heap.pop();
+        remaining_points -= 1;
 
-        // Adjust neighbors of removed point.
-        placeholder_point_area.index = min_point.left_point;
-        var left_point: PointArea = try heap.get(try heap.getIndex(placeholder_point_area));
-        left_point.right_point = min_point.right_point;
+        const left_point = left_points[min_point.index];
+        const right_point = right_points[min_point.index];
 
-        placeholder_point_area.index = min_point.right_point;
-        var right_point: PointArea = try heap.get(try heap.getIndex(placeholder_point_area));
-        right_point.left_point = min_point.left_point;
+        right_points[left_point] = right_point;
+        left_points[right_point] = left_point;
 
-        // Update areas of left and right neighbors.
+        // Update areas of left and right neighbors. Endpoints stay at infinity and cannot be removed.
         try updateNeighborArea(
             &heap,
             left_point,
-            left_point.left_point,
-            left_point.index,
-            left_point.right_point,
+            left_points,
+            right_points,
             uncompressed_values,
         );
         try updateNeighborArea(
             &heap,
             right_point,
-            right_point.left_point,
-            right_point.index,
-            right_point.right_point,
+            left_points,
+            right_points,
             uncompressed_values,
         );
     }
 
-    // Sort remaining points by original index to preserve order.
-    std.mem.sort(PointArea, heap.items[0..heap.len], {}, PointArea.firstThan);
-
     // Output compressed series: first point, then (index, value) pairs.
+    try compressed_values.ensureTotalCapacity(allocator, compressed_values.items.len + 8 + (remaining_points - 1) * 16);
     try shared_functions.appendValue(allocator, f64, uncompressed_values[0], compressed_values);
-    for (1..heap.len) |index| {
-        const point_index = heap.items[index].index;
+    var point_index = right_points[0];
+    while (point_index < point_count) : (point_index = right_points[point_index]) {
         try shared_functions.appendValue(allocator, f64, uncompressed_values[point_index], compressed_values);
         try shared_functions.appendValue(allocator, usize, point_index, compressed_values);
     }
@@ -265,51 +230,12 @@ pub fn rebuild(
     );
 }
 
-/// A `PointArea` represents a point in a series and its associated effective area, which is
-/// calculated based on the triangle formed by the point and its two adjacent neighbors in the
-/// series. The effective area is used to determine the importance of the point in the context
-/// of the Visvalingam-Whyatt line simplification algorithm. Points with smaller areas are less
-/// significant and are more likely to be removed during the simplification process.
-const PointArea = struct {
-    // Index of the point in the original series.
-    index: usize,
-    // Effective area of the point, calculated using the triangle formed by the point and its
-    // two adjacent neighbors.
-    area: f64,
-    // Index of the left (previous) neighbor of the point in the series.
-    left_point: usize,
-    // Index of the right (next) neighbor of the point in the series.
-    right_point: usize,
-
-    /// Order by the `index` field (ascending). This is used to sort points by their original
-    /// position in the series to preserve the order after simplification.
-    fn firstThan(_: void, point_1: PointArea, point_2: PointArea) bool {
-        return point_1.index < point_2.index;
-    }
-};
-
-/// `PointAreaHashContext` provides context for hashing and comparing `PointArea` items for use
-/// in `HashMap`. It defines how `PointArea` are hashed and compared for equality.
-const PointAreaHashContext = struct {
-    /// Hashes the `index: usize` by bitcasting it to `u64`.
-    pub fn hash(_: PointAreaHashContext, merge_error: PointArea) u64 {
-        return @as(u64, @intCast(merge_error.index));
-    }
-    /// Compares two `index` for equality.
-    pub fn eql(_: PointAreaHashContext, merge_error_one: PointArea, merge_error_two: PointArea) bool {
-        return merge_error_one.index == merge_error_two.index;
-    }
-};
-
-/// Comparison function for the `HashedPriorityQueue`. It compares merge errors, and also considers
-/// bucket indices for equality.
-fn comparePointArea(_: void, point_1: PointArea, point_2: PointArea) math.Order {
-    if (point_1.area == point_2.area)
-        return math.Order.eq;
-    return math.order(point_1.area, point_2.area);
-}
-
-/// Return the absolute area of the triangle defined by three points.
+/// Return the absolute area of the triangle defined by three points. The points are represented as
+/// `DiscretePoint` structs, which contain an `index` and a `value`. The `index` represents the
+/// position of the point in the original uncompressed series, while the `value` represents the value
+/// of the point. The function calculates the area using the formula for the area of a triangle given
+/// by three points in a 2D plane, where the x-coordinate is given by the `index` and the y-coordinate
+/// is given by the `value`. The function returns the absolute value of the area.
 fn calculateArea(left_point: DiscretePoint, central_point: DiscretePoint, right_point: DiscretePoint) f64 {
     const x1: f64 = @floatFromInt(left_point.index);
     const y1: f64 = left_point.value;
@@ -321,31 +247,49 @@ fn calculateArea(left_point: DiscretePoint, central_point: DiscretePoint, right_
     return @abs((x1 * (y2 - y3) + x2 * (y3 - y1) + x3 * (y1 - y2)) / 2.0);
 }
 
+/// Return the absolute area of the triangle defined by three points whose indices are `left_index`,
+/// `center_index` and `right_index` and whose values are in the `values` array. The `values` array
+/// is expected to contain the values of the points in the same order as their indices. The function
+/// does not perform any check on the validity of the indices or the values, so it is the caller's
+/// responsibility to ensure that they are correct.
+fn calculateAreaFromValues(values: []const f64, left_index: usize, center_index: usize, right_index: usize) f64 {
+    const x1: f64 = @floatFromInt(left_index);
+    const y1: f64 = values[left_index];
+    const x2: f64 = @floatFromInt(center_index);
+    const y2: f64 = values[center_index];
+    const x3: f64 = @floatFromInt(right_index);
+    const y3: f64 = values[right_index];
+
+    return @abs((x1 * (y2 - y3) + x2 * (y3 - y1) + x3 * (y1 - y2)) / 2.0);
+}
+
+/// Compare two areas for the priority queue. The function returns `math.Order.Less` if `area_1` is less than `area_2`,
+/// `math.Order.Equal` if they are equal and `math.Order.Greater` if `area_1` is greater than `area_2`.
+fn compareArea(area_1: f64, area_2: f64) math.Order {
+    return math.order(area_1, area_2);
+}
+
 /// Update the area of the `neighbor` point in the `heap`. The `left_index`, `center_index` and
 /// `right_index` are the indices of the points in the `uncompressed_values` array. The
 /// `uncompressed_values` are needed to calculate the area of the triangles formed by the three points.
 fn updateNeighborArea(
-    heap: *HashedPriorityQueue(PointArea, void, comparePointArea, PointAreaHashContext),
-    neighbor: PointArea,
-    left_index: usize,
-    center_index: usize,
-    right_index: usize,
+    heap: *IndexedPriorityQueue(f64, compareArea),
+    neighbor_index: usize,
+    left_points: []const usize,
+    right_points: []const usize,
     uncompressed_values: []const f64,
 ) !void {
-    var new_neighbor = neighbor;
-    if (left_index > 0 and right_index < uncompressed_values.len) {
-        // New area of the neighbor point.
-        const new_area = calculateArea(
-            DiscretePoint{ .index = left_index, .value = uncompressed_values[left_index] },
-            DiscretePoint{ .index = center_index, .value = uncompressed_values[center_index] },
-            DiscretePoint{ .index = right_index, .value = uncompressed_values[right_index] },
+    var area = math.inf(f64);
+    if (neighbor_index > 0 and neighbor_index < uncompressed_values.len - 1) {
+        area = calculateAreaFromValues(
+            uncompressed_values,
+            left_points[neighbor_index],
+            neighbor_index,
+            right_points[neighbor_index],
         );
-
-        new_neighbor.area = new_area;
     }
-    // Update the neighbor in the heap. Even if the area is not changed, it is necessary to update the
-    // neighbor to update the pointer to its adjacent points.
-    try heap.update(neighbor, new_neighbor);
+
+    try heap.update(neighbor_index, area);
 }
 
 /// Test if the area of all the triangles defined by three points contained in `values`
@@ -440,6 +384,34 @@ test "vw compress and compress with known result" {
     // this value except when removing the element in position 5. Therefore, the area of the triangles formed by the
     // slices of the removed points from 0..5 should be less than 2.5.
     try testAreaWithinErrorBound(uncompressed_values[0..6], 2.5);
+}
+
+test "vw compress recalculates areas for points next to endpoints" {
+    const allocator = testing.allocator;
+
+    const uncompressed_values: []const f64 = &[_]f64{ 1.0, 3.0, 4.0, 1.0 };
+    const method_configuration =
+        \\ {"area_under_curve_error": 2.5}
+    ;
+
+    var compressed_values = ArrayList(u8).empty;
+    defer compressed_values.deinit(allocator);
+    var decompressed_values = ArrayList(f64).empty;
+    defer decompressed_values.deinit(allocator);
+
+    try compress(
+        allocator,
+        uncompressed_values,
+        &compressed_values,
+        method_configuration,
+    );
+    try decompress(allocator, compressed_values.items, &decompressed_values);
+
+    const compressed_representation = mem.bytesAsSlice(f64, compressed_values.items);
+    try testing.expectEqual(@as(usize, 5), compressed_representation.len);
+    try testing.expectEqual(@as(usize, 2), @as(usize, @bitCast(compressed_representation[2])));
+    try testing.expectEqual(@as(usize, 3), @as(usize, @bitCast(compressed_representation[4])));
+    try testing.expectEqualSlices(f64, &[_]f64{ 1.0, 2.5, 4.0, 1.0 }, decompressed_values.items);
 }
 
 test "vw compress and compress with random data" {

--- a/src/lossy_compression/line_simplification/visvalingam_whyatt.zig
+++ b/src/lossy_compression/line_simplification/visvalingam_whyatt.zig
@@ -129,7 +129,7 @@ pub fn compress(
         );
     }
 
-    // Output compressed series: first point, then (index, value) pairs.
+    // Output compressed series: first point, then (value, index) pairs.
     try compressed_values.ensureTotalCapacity(allocator, compressed_values.items.len + 8 + (remaining_points - 1) * 16);
     try shared_functions.appendValue(allocator, f64, uncompressed_values[0], compressed_values);
     var point_index = right_points[0];

--- a/src/lossy_compression/value_representation/histogram_representation.zig
+++ b/src/lossy_compression/value_representation/histogram_representation.zig
@@ -820,9 +820,8 @@ test "Random clusters, elements per cluster and values for PWCH" {
     const max_counts_per_cluster: usize = 100;
 
     var current_min_value = min_value;
-    for (0..number_of_cluster) |i| {
-        const momentum: f64 = if (i < number_of_cluster / 2) 1.0 else -1.0;
-        const cluster_min = current_min_value + momentum * gap;
+    for (0..number_of_cluster) |_| {
+        const cluster_min = current_min_value + gap;
         const cluster_max = cluster_min + cluster_width;
         const count: usize = random.uintLessThan(usize, max_counts_per_cluster) + 10;
         // Append the cluster to cluster_ranges.

--- a/src/lossy_compression/value_representation/serf_qt.zig
+++ b/src/lossy_compression/value_representation/serf_qt.zig
@@ -55,9 +55,6 @@ pub fn compress(
 
     const bucket_size: f64 = shared_functions.createQuantizationBucket(error_bound);
 
-    // Append the minimum value to the header of the compressed values.
-    try shared_functions.appendValue(allocator, f64, bucket_size, compressed_values);
-
     //Intermediate quantized values.
     var quantized_values = ArrayList(u64).empty;
     defer quantized_values.deinit(allocator);
@@ -69,7 +66,7 @@ pub fn compress(
     // If the error_bound is zero, we compute the difference between the
     // value and the minimum value, ensuring all resulting integers are >= 0.
     // For non-zero error_bound, we apply fixed-width bucket quantization
-    // using the defined bucket size (1.998 × error_bound).
+    // using the defined bucket size (1.99 * error_bound).
     var encoded_value: u64 = 0;
     for (uncompressed_values) |value| {
         if (!math.isFinite(value) or @abs(value) > tester.max_test_value) return Error.UnsupportedInput;
@@ -82,18 +79,30 @@ pub fn compress(
             encoded_value = u64_value;
         } else {
             // Fixed-width bucket quantization with rounding (Equation 2).
-            const quantized_value: i64 = @intFromFloat(@round((value - previous_value) / bucket_size));
+            const scaled_value = @round((value - previous_value) / bucket_size);
+            // If the scaled value is not finite or exceeds the representable range of i64, return an error.
+            if (!math.isFinite(scaled_value) or
+                scaled_value < @as(f64, @floatFromInt(math.minInt(i64))) or
+                scaled_value > @as(f64, @floatFromInt(math.maxInt(i64))))
+            {
+                return Error.UnsupportedInput;
+            }
+            const quantized_value: i64 = @intFromFloat(scaled_value);
             // Apply zigzag encoding to handle negative values (Equation 4).
             // Add 1 to ensure non-zero values for Elias Gamma encoding.
             encoded_value = shared_functions.encodeZigZag(quantized_value) + 1;
 
             // Predict the next value (Equation 3) and use it as previous value.
             const predict_value = previous_value + @as(f64, @floatFromInt(quantized_value)) * bucket_size;
+            if (@abs(value - predict_value) > error_bound) return Error.UnsupportedInput;
             previous_value = predict_value;
         }
 
         try quantized_values.append(allocator, encoded_value);
     }
+
+    // Append the bucket size to the header after all values are validated.
+    try shared_functions.appendValue(allocator, f64, bucket_size, compressed_values);
 
     // Encode the quantized values using Elias Gamma encoding.
     try shared_functions.encodeEliasGamma(allocator, quantized_values.items, compressed_values);
@@ -214,7 +223,7 @@ test "serf-qt cannot compress and decompress values exceeding floating-point pre
 
 test "serf-qt can compress and decompress within floating-point precision limits at different scales" {
     const allocator = testing.allocator;
-    const error_bound = tester.generateBoundedRandomValue(f32, 0, 1e3, null);
+    const error_bound = tester.generateBoundedRandomValue(f32, 1e2, 1e3, null);
 
     var uncompressed_values = ArrayList(f64).empty;
     defer uncompressed_values.deinit(allocator);
@@ -233,6 +242,93 @@ test "serf-qt can compress and decompress within floating-point precision limits
         error_bound,
         shared_functions.isWithinErrorBound,
     );
+}
+
+test "serf-qt stays within error bound after large prediction deltas" {
+    const allocator = testing.allocator;
+    const error_bound: f32 = 100.0;
+
+    const uncompressed_values = &[_]f64{
+        0.0,
+        9.999999999995e13,
+        9.999999999997e13,
+        -9.999999999996e13,
+        -9.999999999994e13,
+        128.25,
+        -96.75,
+    };
+
+    var compressed_values = ArrayList(u8).empty;
+    defer compressed_values.deinit(allocator);
+    var decompressed_values = ArrayList(f64).empty;
+    defer decompressed_values.deinit(allocator);
+
+    const method_configuration = try std.fmt.allocPrint(
+        allocator,
+        "{{\"abs_error_bound\": {d}}}",
+        .{error_bound},
+    );
+    defer allocator.free(method_configuration);
+
+    try compress(
+        allocator,
+        uncompressed_values,
+        &compressed_values,
+        method_configuration,
+    );
+    try decompress(allocator, compressed_values.items, &decompressed_values);
+
+    try testing.expect(shared_functions.isWithinErrorBound(
+        uncompressed_values,
+        decompressed_values.items,
+        error_bound,
+    ));
+}
+
+test "serf-qt rejects positive error bounds below floating-point precision limits" {
+    const allocator = testing.allocator;
+
+    const uncompressed_values = &[_]f64{
+        0.0,
+        100000000000000.0,
+        100000000000010.0,
+    };
+
+    var compressed_values = ArrayList(u8).empty;
+    defer compressed_values.deinit(allocator);
+
+    const method_configuration =
+        \\ {"abs_error_bound": 0.01}
+    ;
+
+    try testing.expectError(Error.UnsupportedInput, compress(
+        allocator,
+        uncompressed_values,
+        &compressed_values,
+        method_configuration,
+    ));
+    try testing.expectEqual(@as(usize, 0), compressed_values.items.len);
+}
+
+test "serf-qt rejects quantized deltas that cannot be represented" {
+    const allocator = testing.allocator;
+
+    const uncompressed_values = &[_]f64{100000000000000.0};
+
+    var compressed_values = ArrayList(u8).empty;
+    defer compressed_values.deinit(allocator);
+
+    const method_configuration =
+        \\ {"abs_error_bound": 0.000001}
+    ;
+
+    try testing.expectError(Error.UnsupportedInput, compress(
+        allocator,
+        uncompressed_values,
+        &compressed_values,
+        method_configuration,
+    ));
+    try testing.expectEqual(@as(usize, 0), compressed_values.items.len);
 }
 
 test "serf-qt can compress and decompress with zero error bound at different scales" {

--- a/src/utilities/indexed_priority_queue.zig
+++ b/src/utilities/indexed_priority_queue.zig
@@ -1,0 +1,343 @@
+// Copyright 2026 TerseTS Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Implementation of an indexed priority queue for dense `usize` indices.
+//!
+//! The queue is intended for algorithms whose items are identified by stable dense indices in the
+//! range `0..capacity`. Unlike `HashedPriorityQueue`, this implementation does not use a hash map
+//! to find or update existing elements. Instead, it stores the current state for each dense index
+//! in arrays and keeps heap updates cheap by pushing a new version of the changed element. Older
+//! heap entries are discarded lazily when they reach the top of the heap.
+//!
+//! This representation is useful for hot loops where the caller already has dense indices, such as
+//! time-series algorithms operating over positions in an input slice. For sparse keys or keys that
+//! are not naturally represented as dense `usize` values, use `HashedPriorityQueue` instead.
+
+const std = @import("std");
+const math = std.math;
+const mem = std.mem;
+const Order = std.math.Order;
+const testing = std.testing;
+const Allocator = mem.Allocator;
+const ArrayList = std.ArrayList;
+
+const expectEqual = testing.expectEqual;
+const expectError = testing.expectError;
+
+/// Errors returned by `IndexedPriorityQueue`.
+pub const Error = error{
+    EmptyQueue,
+    ItemNotFound,
+    OutOfMemory,
+};
+
+/// A priority queue for items identified by dense `usize` indices.
+/// Similar as with Zig's std.PriorityQueue, initialize with `init`. Provide `compareFn` that
+/// returns an `Order` enum to compare priorities, e.g., return `Order.lt` if the first priority
+/// should be popped before the second priority. If two priorities compare equal, the item with
+/// the smaller dense index is popped first to keep the behavior deterministic.
+/// `capacity` passed to `init` defines the valid index range for the lifetime of the queue:
+/// `0..capacity`. Indices outside that range return `Error.ItemNotFound`.
+pub fn IndexedPriorityQueue(
+    comptime T: type,
+    comptime compareFn: fn (a: T, b: T) Order,
+) type {
+    return struct {
+        const Self = @This();
+
+        /// Public representation returned by `peek` and `pop`.
+        pub const Entry = struct {
+            /// Dense index associated with the priority.
+            index: usize,
+            /// Current priority for `index`.
+            priority: T,
+        };
+
+        /// Internal heap entry. `version` identifies stale copies left in the heap after updates.
+        const HeapEntry = struct {
+            /// Dense index associated with the priority.
+            index: usize,
+            /// Priority captured when this heap entry was inserted.
+            priority: T,
+            /// Version captured when this heap entry was inserted.
+            version: usize,
+        };
+
+        /// Elements forming the heap. Stale entries may exist until they reach the heap root.
+        items: ArrayList(HeapEntry),
+        /// Number of currently active dense indices in the queue.
+        len: usize,
+        /// Allocator used for memory management.
+        allocator: Allocator,
+        /// Current priority for each dense index.
+        priorities: []T,
+        /// Current version for each dense index.
+        versions: []usize,
+        /// Whether each dense index is currently present in the queue.
+        is_active: []bool,
+
+        /// Initializes a new `IndexedPriorityQueue` with valid indices in `0..initial_capacity`.
+        pub fn init(allocator: Allocator, initial_capacity: usize) Error!Self {
+            const priorities = try allocator.alloc(T, initial_capacity);
+            errdefer allocator.free(priorities);
+
+            const versions = try allocator.alloc(usize, initial_capacity);
+            errdefer allocator.free(versions);
+
+            const is_active = try allocator.alloc(bool, initial_capacity);
+            errdefer allocator.free(is_active);
+
+            @memset(versions, 0);
+            @memset(is_active, false);
+
+            var items = ArrayList(HeapEntry).empty;
+            errdefer items.deinit(allocator);
+            try items.ensureTotalCapacity(allocator, initial_capacity);
+
+            return Self{
+                .items = items,
+                .len = 0,
+                .allocator = allocator,
+                .priorities = priorities,
+                .versions = versions,
+                .is_active = is_active,
+            };
+        }
+
+        /// Frees memory used by the queue.
+        pub fn deinit(self: *Self) void {
+            self.items.deinit(self.allocator);
+            self.allocator.free(self.priorities);
+            self.allocator.free(self.versions);
+            self.allocator.free(self.is_active);
+        }
+
+        /// Returns the number of active indices in the queue.
+        pub fn count(self: *const Self) usize {
+            return self.len;
+        }
+
+        /// Returns the current capacity of the queue, which is also the exclusive upper bound of
+        /// valid dense indices.
+        pub fn capacity(self: *const Self) usize {
+            return self.is_active.len;
+        }
+
+        /// Returns whether `index` is currently present in the queue.
+        pub fn contains(self: *const Self, index: usize) bool {
+            return index < self.capacity() and self.is_active[index];
+        }
+
+        /// Inserts `index` with `priority`, maintaining the heap property.
+        pub fn add(self: *Self, index: usize, priority: T) Error!void {
+            if (index >= self.capacity()) return Error.ItemNotFound;
+            if (self.is_active[index]) return Error.ItemNotFound;
+
+            self.is_active[index] = true;
+            self.priorities[index] = priority;
+            self.versions[index] += 1;
+            self.len += 1;
+            try self.pushHeap(.{
+                .index = index,
+                .priority = priority,
+                .version = self.versions[index],
+            });
+        }
+
+        /// Updates `index` with `priority`.
+        /// Updates are implemented by pushing a new heap entry and incrementing the version for the
+        /// index. Older heap entries become stale and are discarded lazily by `peek` or `pop`.
+        pub fn update(self: *Self, index: usize, priority: T) Error!void {
+            if (!self.contains(index)) return Error.ItemNotFound;
+
+            self.priorities[index] = priority;
+            self.versions[index] += 1;
+            try self.pushHeap(.{
+                .index = index,
+                .priority = priority,
+                .version = self.versions[index],
+            });
+        }
+
+        /// Removes `index` from the queue.
+        /// Any heap entries already inserted for `index` become stale and are discarded lazily.
+        pub fn remove(self: *Self, index: usize) Error!void {
+            if (!self.contains(index)) return Error.ItemNotFound;
+
+            self.is_active[index] = false;
+            self.versions[index] += 1;
+            self.len -= 1;
+        }
+
+        /// Returns the minimum active entry without removing it.
+        pub fn peek(self: *Self) Error!Entry {
+            try self.discardStaleHeapEntries();
+            if (self.items.items.len == 0) return Error.EmptyQueue;
+
+            const entry = self.items.items[0];
+            return Entry{ .index = entry.index, .priority = entry.priority };
+        }
+
+        /// Removes and returns the minimum active entry.
+        pub fn pop(self: *Self) Error!Entry {
+            try self.discardStaleHeapEntries();
+            if (self.items.items.len == 0) return Error.EmptyQueue;
+
+            const entry = try self.popHeap();
+            self.is_active[entry.index] = false;
+            self.versions[entry.index] += 1;
+            self.len -= 1;
+            return Entry{ .index = entry.index, .priority = entry.priority };
+        }
+
+        /// Returns whether `entry` still represents the current active state for its dense index.
+        fn isActiveHeapEntry(self: *const Self, entry: HeapEntry) bool {
+            return self.is_active[entry.index] and entry.version == self.versions[entry.index];
+        }
+
+        /// Removes stale heap roots until the root is active or the heap is empty.
+        fn discardStaleHeapEntries(self: *Self) Error!void {
+            while (self.items.items.len > 0 and !self.isActiveHeapEntry(self.items.items[0])) {
+                _ = try self.popHeap();
+            }
+        }
+
+        /// Inserts a heap entry, maintaining the heap property by sifting it up.
+        fn pushHeap(self: *Self, entry: HeapEntry) Error!void {
+            try self.items.append(self.allocator, entry);
+
+            var child_index = self.items.items.len - 1;
+            while (child_index > 0) {
+                const parent_index = (child_index - 1) >> 1;
+                if (!heapEntryLessThan(self.items.items[child_index], self.items.items[parent_index])) break;
+
+                mem.swap(HeapEntry, &self.items.items[child_index], &self.items.items[parent_index]);
+                child_index = parent_index;
+            }
+        }
+
+        /// Removes and returns the heap root without checking whether it is active.
+        fn popHeap(self: *Self) Error!HeapEntry {
+            if (self.items.items.len == 0) return Error.EmptyQueue;
+
+            const min_entry = self.items.items[0];
+            const last_entry = self.items.pop().?;
+            if (self.items.items.len == 0) return min_entry;
+
+            self.items.items[0] = last_entry;
+            var index: usize = 0;
+            while (true) {
+                const left_child_index = (math.mul(usize, index, 2) catch break) | 1;
+                if (left_child_index >= self.items.items.len) break;
+
+                const right_child_index = left_child_index + 1;
+                var lesser_child_index = left_child_index;
+                if (right_child_index < self.items.items.len and
+                    heapEntryLessThan(self.items.items[right_child_index], self.items.items[left_child_index]))
+                {
+                    lesser_child_index = right_child_index;
+                }
+
+                if (!heapEntryLessThan(self.items.items[lesser_child_index], self.items.items[index])) break;
+
+                mem.swap(HeapEntry, &self.items.items[index], &self.items.items[lesser_child_index]);
+                index = lesser_child_index;
+            }
+
+            return min_entry;
+        }
+
+        /// Returns whether `entry_1` has higher priority than `entry_2`.
+        fn heapEntryLessThan(entry_1: HeapEntry, entry_2: HeapEntry) bool {
+            return switch (compareFn(entry_1.priority, entry_2.priority)) {
+                .lt => true,
+                .eq => entry_1.index < entry_2.index,
+                .gt => false,
+            };
+        }
+    };
+}
+
+fn compareF64(a: f64, b: f64) Order {
+    return math.order(a, b);
+}
+
+test "indexed priority queue pops entries by priority" {
+    const allocator = testing.allocator;
+
+    var queue = try IndexedPriorityQueue(f64, compareF64).init(allocator, 5);
+    defer queue.deinit();
+
+    try queue.add(3, 3.0);
+    try queue.add(1, 1.0);
+    try queue.add(4, 4.0);
+    try queue.add(2, 2.0);
+
+    try expectEqual(@as(usize, 4), queue.count());
+    try expectEqual(@as(usize, 5), queue.capacity());
+    try expectEqual(@as(usize, 1), (try queue.pop()).index);
+    try expectEqual(@as(usize, 2), (try queue.pop()).index);
+    try expectEqual(@as(usize, 3), (try queue.pop()).index);
+    try expectEqual(@as(usize, 4), (try queue.pop()).index);
+    try expectError(Error.EmptyQueue, queue.pop());
+}
+
+test "indexed priority queue update discards stale priorities" {
+    const allocator = testing.allocator;
+
+    var queue = try IndexedPriorityQueue(f64, compareF64).init(allocator, 4);
+    defer queue.deinit();
+
+    try queue.add(0, 10.0);
+    try queue.add(1, 20.0);
+    try queue.add(2, 30.0);
+
+    try queue.update(2, 1.0);
+    try expectEqual(@as(usize, 2), (try queue.peek()).index);
+    try expectEqual(@as(usize, 2), (try queue.pop()).index);
+    try expectEqual(@as(usize, 0), (try queue.pop()).index);
+    try expectEqual(@as(usize, 1), (try queue.pop()).index);
+}
+
+test "indexed priority queue removal invalidates pending entries" {
+    const allocator = testing.allocator;
+
+    var queue = try IndexedPriorityQueue(f64, compareF64).init(allocator, 4);
+    defer queue.deinit();
+
+    try queue.add(0, 1.0);
+    try queue.add(1, 0.5);
+    try queue.add(2, 2.0);
+    try queue.remove(1);
+
+    try testing.expect(!queue.contains(1));
+    try expectEqual(@as(usize, 0), (try queue.pop()).index);
+    try expectEqual(@as(usize, 2), (try queue.pop()).index);
+    try expectError(Error.EmptyQueue, queue.pop());
+}
+
+test "indexed priority queue breaks equal-priority ties by index" {
+    const allocator = testing.allocator;
+
+    var queue = try IndexedPriorityQueue(f64, compareF64).init(allocator, 4);
+    defer queue.deinit();
+
+    try queue.add(3, 1.0);
+    try queue.add(1, 1.0);
+    try queue.add(2, 1.0);
+
+    try expectEqual(@as(usize, 1), (try queue.pop()).index);
+    try expectEqual(@as(usize, 2), (try queue.pop()).index);
+    try expectEqual(@as(usize, 3), (try queue.pop()).index);
+}

--- a/src/utilities/indexed_priority_queue.zig
+++ b/src/utilities/indexed_priority_queue.zig
@@ -140,6 +140,7 @@ pub fn IndexedPriorityQueue(
         }
 
         /// Inserts `index` with `priority`, maintaining the heap property.
+        /// Returns `Error.ItemNotFound` if `index` is out of range or already present in the queue.
         pub fn add(self: *Self, index: usize, priority: T) Error!void {
             if (index >= self.capacity()) return Error.ItemNotFound;
             if (self.is_active[index]) return Error.ItemNotFound;


### PR DESCRIPTION
### Summary

Refactored dense-index heap usage out of Visvalingam-Whyatt and Bottom-Up into a shared IndexedPriorityQueue utility.

### Files Added/Modified

Heap Changes

  - Added src/utilities/indexed_priority_queue.zig.
  - New heap is designed for stable dense usize keys in 0..capacity.
  - Avoids hash-map lookups used by HashedPriorityQueue.

Compression Algorithm Changes

  - Refactored Visvalingam-Whyatt to use IndexedPriorityQueue.
  - Refactored Bottom-Up to use IndexedPriorityQueue.
