### PR TITLE
Initial commit for gorilla implementation

### DIFF
--- a/bindings/c/tersets.h
+++ b/bindings/c/tersets.h
@@ -34,6 +34,7 @@ enum Method {
   DiscreteFourierTransform      = 22,
   MacaqueS                      = 23,
   MacaqueV                      = 24,
+  Gorilla                       = 25,
 };
 
 // A pointer to uncompressed values and the number of values.

--- a/bindings/julia/TerseTS.jl
+++ b/bindings/julia/TerseTS.jl
@@ -45,6 +45,7 @@ Mirror TerseTS Method Enum.
     DiscreteFourierTransform = 22
     MacaqueS = 23
     MacaqueV = 24
+    Gorilla = 25
 end
 
 """

--- a/bindings/python/tersets/__init__.py
+++ b/bindings/python/tersets/__init__.py
@@ -106,8 +106,8 @@ class __Coefficients(Structure):
 # Declare function signatures to avoid silent arguments mismatch.
 __library.compress.argtypes = [
     __UncompressedValues,
-    POINTER(__CompressedValues), 
-    c_uint8, 
+    POINTER(__CompressedValues),
+    c_uint8,
     c_char_p,
 ]
 __library.compress.restype = c_int
@@ -116,19 +116,19 @@ __library.decompress.argtypes = [__CompressedValues, POINTER(__UncompressedValue
 __library.decompress.restype = c_int
 
 __library.extract.argtypes = [
-    __CompressedValues, 
-    POINTER(__Indices), 
+    __CompressedValues,
+    POINTER(__Indices),
     POINTER(__Coefficients),
 ]
-__library.extract.restype  = c_int
+__library.extract.restype = c_int
 
 __library.rebuild.argtypes = [
-    __Indices, 
-    __Coefficients, 
-    POINTER(__CompressedValues), 
+    __Indices,
+    __Coefficients,
+    POINTER(__CompressedValues),
     c_ubyte,
 ]
-__library.rebuild.restype  = c_int
+__library.rebuild.restype = c_int
 
 
 # Mirror the compression methods provided by TerseTS.
@@ -159,6 +159,7 @@ class Method(Enum):
     DiscreteFourierTransform = 22
     MacaqueS = 23
     MacaqueV = 24
+    Gorilla = 25
 
 
 # Public API.
@@ -213,9 +214,16 @@ def compress(
         # If `values` is already float64 and C-contiguous, no copy is made.
         # Otherwise, numpy.ascontiguousarray() converts it (potentially copying)
         # so we can safely pass its data pointer directly to the native layer.
-        if uncompressed_values.dtype != numpy.float64 or not uncompressed_values.flags["C_CONTIGUOUS"]:
-            uncompressed_values = numpy.ascontiguousarray(uncompressed_values, dtype=numpy.float64)
-        uncompressed_values_struct.data = uncompressed_values.ctypes.data_as(POINTER(c_double))
+        if (
+            uncompressed_values.dtype != numpy.float64
+            or not uncompressed_values.flags["C_CONTIGUOUS"]
+        ):
+            uncompressed_values = numpy.ascontiguousarray(
+                uncompressed_values, dtype=numpy.float64
+            )
+        uncompressed_values_struct.data = uncompressed_values.ctypes.data_as(
+            POINTER(c_double)
+        )
         uncompressed_values_struct.len = uncompressed_values.size
     elif isinstance(uncompressed_values, (list, tuple)):
         # Build a contiguous C array of f64 values from the Python sequence.
@@ -249,13 +257,13 @@ def compress(
             uncompressed_values_struct,
             byref(compressed_values_struct),
             c_uint8(method.value),
-            c_char_p(json_configuration)
+            c_char_p(json_configuration),
         )
         if tersets_error != 0:
             raise RuntimeError(f"compress failed: {tersets_error}")
-        
+
         if _INSTALLED_NUMPY:
-            # The native layer allocates `compressed_values_struct.data`. 
+            # The native layer allocates `compressed_values_struct.data`.
             # Copy into NumPy-owned memory before freeing the Zig arrays.
             return numpy.ctypeslib.as_array(
                 cast(compressed_values_struct.data, POINTER(c_ubyte)),
@@ -275,7 +283,7 @@ def decompress(
 ) -> Union[List[float], "numpy.ndarray"]:
     """Decompress a TerseTS-compressed array into a list of floats.
 
-    This function restores the float64 values from a compressed TerseTS compressed 
+    This function restores the float64 values from a compressed TerseTS compressed
     representation. When NumPy is installed, it uses a zero-copy view of the input array and
     an efficient conversion to Python list. The function accepts compressed input as `bytes`,
     `bytearray`, `memoryview`, or a `numpy.ndarray[uint8]`. If NumPy is installed, returns a
@@ -369,11 +377,11 @@ def extract(
     """Extract indices and coefficients from a compressed TerseTS compressed representation.
 
     This function parses a compressed representation and returns its internal
-    representation as two arrays: indices and coefficients. In this context, 
+    representation as two arrays: indices and coefficients. In this context,
     indices are method-dependent metadata need to reconstruct the original time series,
     e.g., indices of key points, segment boundaries, or histogram bin indices.
     Coefficients are the floating-point values associated with these indices.
-    Pass `values` as `bytes` for the fastest processing using Python or install 
+    Pass `values` as `bytes` for the fastest processing using Python or install
     NumPy to enable efficient memory handling and avoid unnecessary copies.
 
     Args:
@@ -414,7 +422,9 @@ def extract(
         if not compressed_values.flags["C_CONTIGUOUS"]:
             raise TypeError("NumPy array must be C-contiguous")
 
-        compressed_values_struct.data = compressed_values.ctypes.data_as(POINTER(c_ubyte))
+        compressed_values_struct.data = compressed_values.ctypes.data_as(
+            POINTER(c_ubyte)
+        )
         compressed_values_struct.len = compressed_values.size
 
     elif isinstance(compressed_values, (bytes, bytearray, memoryview)):
@@ -425,7 +435,9 @@ def extract(
             compressed_values_struct.len = view.size
         else:
             # ctypes fallback.
-            buffer = (c_ubyte * len(compressed_values)).from_buffer_copy(compressed_values)
+            buffer = (c_ubyte * len(compressed_values)).from_buffer_copy(
+                compressed_values
+            )
             compressed_values_struct.data = cast(buffer, POINTER(c_ubyte))
             compressed_values_struct.len = len(compressed_values)
 
@@ -439,8 +451,8 @@ def extract(
 
     try:
         tersets_error = __library.extract(
-            compressed_values_struct, 
-            byref(indices_struct), 
+            compressed_values_struct,
+            byref(indices_struct),
             byref(coefficients_struct),
         )
         if tersets_error != 0:
@@ -449,10 +461,12 @@ def extract(
         if _INSTALLED_NUMPY:
             # Create views onto native memory, then copy into NumPy-owned arrays
             # before we free the native allocations in `finally`.
-            indices = numpy.ctypeslib.as_array(indices_struct.data, 
-                                               shape=(indices_struct.len,)).copy()
-            coefficients = numpy.ctypeslib.as_array(coefficients_struct.data, 
-                                                    shape=(coefficients_struct.len,)).copy()
+            indices = numpy.ctypeslib.as_array(
+                indices_struct.data, shape=(indices_struct.len,)
+            ).copy()
+            coefficients = numpy.ctypeslib.as_array(
+                coefficients_struct.data, shape=(coefficients_struct.len,)
+            ).copy()
             return indices, coefficients
 
         # No NumPy: copy into Python lists.
@@ -465,7 +479,7 @@ def extract(
             __library.freeIndices(byref(indices_struct))
         if coefficients_struct.data:
             __library.freeCoefficients(byref(coefficients_struct))
-        
+
 
 def rebuild(
     indices: Union["numpy.ndarray", List[int], Tuple[int, ...]],
@@ -475,19 +489,19 @@ def rebuild(
     """Rebuild a compressed TerseTS representation from extracted indices and coefficients.
 
     This function is the inverse of :func:`extract` and constructs a valid
-    binary compressed representation from the method-specific arrays `indices` 
+    binary compressed representation from the method-specific arrays `indices`
     and `coefficients`. In this context, indices are method-dependent metadata
-    needed to reconstruct the original time series, e.g., indices of key points, 
+    needed to reconstruct the original time series, e.g., indices of key points,
     segment boundaries, or histogram bin indices. Coefficients are the floating-point
     values associated with these indices. The returned representation is identical in
-    format to what :func:`compress` would produce for the same method. 
-    
+    format to what :func:`compress` would produce for the same method.
+
     The meaning and required structure of `indices` and `coefficients`
-    depend on the selected compression method. 
-    
-    TerseTS performs structural validation and will return an error 
-    if the arrays do not satisfy the invariants of the target `method`. 
-    
+    depend on the selected compression method.
+
+    TerseTS performs structural validation and will return an error
+    if the arrays do not satisfy the invariants of the target `method`.
+
     When NumPy is installed, the function uses a zero-copy view of both input arrays
     (if they are C-contiguous and of the correct dtype), making this significantly
     faster for large arrays. Otherwise, it falls back to building temporary ctypes arrays.
@@ -516,7 +530,7 @@ def rebuild(
     Notes:
       - NumPy-based zero-copy input requires arrays to be C-contiguous and of the correct dtype.
       - Output is copied into Python/NumPy-owned memory before freeing the Zig array.
-    
+
     Examples:
       >>> configuration = {"abs_error_bound": 0.1}
       >>> blob = compress([1.0, 2.08, 2.96], Method.SwingFilter, configuration)
@@ -548,17 +562,25 @@ def rebuild(
         indices_struct.data = indices_buffer
         indices_struct.len = len(indices)
     else:
-        raise TypeError("rebuild(): 'indices' must be ndarray[uintp] or list/tuple[int]")
+        raise TypeError(
+            "rebuild(): 'indices' must be ndarray[uintp] or list/tuple[int]"
+        )
 
     # Prepare coefficients (double*).
     coefficients_struct = __Coefficients()
     if _INSTALLED_NUMPY and isinstance(coefficients, numpy.ndarray):
         if coefficients.dtype != numpy.float64:
-            raise TypeError("rebuild(): 'coefficients' NumPy array must have dtype=np.float64")
+            raise TypeError(
+                "rebuild(): 'coefficients' NumPy array must have dtype=np.float64"
+            )
         if coefficients.ndim != 1:
-            raise TypeError("rebuild(): 'coefficients' NumPy array must be 1-dimensional")
+            raise TypeError(
+                "rebuild(): 'coefficients' NumPy array must be 1-dimensional"
+            )
         if not coefficients.flags["C_CONTIGUOUS"]:
-            raise TypeError("rebuild(): 'coefficients' NumPy array must be C-contiguous")
+            raise TypeError(
+                "rebuild(): 'coefficients' NumPy array must be C-contiguous"
+            )
 
         coefficients_struct.data = coefficients.ctypes.data_as(POINTER(c_double))
         coefficients_struct.len = coefficients.size
@@ -567,7 +589,9 @@ def rebuild(
         coefficients_struct.data = buffer
         coefficients_struct.len = len(coefficients)
     else:
-        raise TypeError("rebuild(): 'coefficients' must be ndarray[float64] or list/tuple[float]")
+        raise TypeError(
+            "rebuild(): 'coefficients' must be ndarray[float64] or list/tuple[float]"
+        )
 
     compressed_values_struct = __CompressedValues()
 

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -52,6 +52,7 @@ pub enum Method {
     DiscreteFourierTransform,
     MacaqueS,
     MacaqueV,
+    Gorilla,
 }
 
 /// Compress a slice of [`f64`] in `uncompressed_values` to a [`Vec`] of [`u8`] with a TerseTS

--- a/src/capi.zig
+++ b/src/capi.zig
@@ -313,6 +313,7 @@ test "method enum must match method constants" {
     try testing.expectEqual(@intFromEnum(tersets.Method.DiscreteFourierTransform), 22);
     try testing.expectEqual(@intFromEnum(tersets.Method.MacaqueS), 23);
     try testing.expectEqual(@intFromEnum(tersets.Method.MacaqueV), 24);
+    try testing.expectEqual(@intFromEnum(tersets.Method.Gorilla), 25);
 }
 
 test "error for unknown compression method" {

--- a/src/configuration.zig
+++ b/src/configuration.zig
@@ -214,6 +214,7 @@ pub fn defaultConfigurationBuilder(
         .RunLengthEncoding,
         .Chimp64,
         .Chimp128,
+        .Gorilla,
         .BitPackedDeltaEncoding,
         => try allocator.dupe(u8, "{}"),
     };

--- a/src/lossless_compression/gorilla.zig
+++ b/src/lossless_compression/gorilla.zig
@@ -1,0 +1,227 @@
+// Copyright 2026 TerseTS Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Implementation of Gorilla
+
+const std = @import("std");
+const mem = std.mem;
+const Allocator = mem.Allocator;
+const ArrayList = std.ArrayList;
+const testing = std.testing;
+
+const tersets = @import("../tersets.zig");
+const configuration = @import("../configuration.zig");
+const Method = tersets.Method;
+const Error = tersets.Error;
+
+const tester = @import("../tester.zig");
+const shared_functions = @import("../utilities/shared_functions.zig");
+const shared_structs = @import("../utilities/shared_structs.zig");
+
+/// Compresses the `uncompressed_values` using "Gorilla". The function writes the
+/// result to `compressed_values`. The `method_configuration` is expected to be `EmptyConfiguration`,
+/// otherwise an error is returned instead of ignoring the configuration. The `allocator` is used
+/// to allocate the `method_configuration` p arser's memory. If an error occurs it is returned.
+pub fn compress(
+    allocator: Allocator,
+    uncompressed_values: []const f64,
+    compressed_values: *ArrayList(u8),
+    method_configuration: []const u8,
+) Error!void {
+    _ = try configuration.parse(
+        allocator,
+        configuration.EmptyConfiguration,
+        method_configuration,
+    );
+
+    try shared_functions.appendValue(allocator, u64, @intCast(uncompressed_values.len), compressed_values);
+    if (uncompressed_values.len == 0) return;
+
+    // Store first value and xor subsequent values against it
+    const first_value: f64 = uncompressed_values[0];
+    try shared_functions.appendValue(allocator, f64, first_value, compressed_values);
+
+    const dtype_bit_len: u7 = @bitSizeOf(@TypeOf(first_value));
+
+    var bit_writer = try shared_structs.BulkBitWriter.init(allocator, compressed_values);
+
+    var prev_value_bits: u64 = @bitCast(first_value);
+    var leading_zeros: u8 = dtype_bit_len + 1;
+    var trailing_zeros: u8 = dtype_bit_len + 1;
+    var meaningful_len: u8 = 0;
+    for (uncompressed_values[1..]) |value| {
+        const current_value_bits: u64 = @bitCast(value);
+        const xor = prev_value_bits ^ current_value_bits;
+        if (xor == 0) {
+            try bit_writer.writeBits(@as(u1, 0), 1);
+        } else {
+            // write header
+            try bit_writer.writeBits(@as(u1, 1), 1);
+            const l: u5 = @min(@clz(xor), 31);
+            const t: u8 = @ctz(xor);
+            if (l >= leading_zeros and t >= trailing_zeros) {
+                // nested region
+                try bit_writer.writeBits(@as(u1, 0), 1);
+            } else {
+                // not nested, need to first record the new leading/trailing count
+                try bit_writer.writeBits(@as(u1, 1), 1);
+                meaningful_len = @intCast(dtype_bit_len - l - t);
+                try bit_writer.writeBits(l, 5);
+                try bit_writer.writeBits(meaningful_len - 1, 6);
+                leading_zeros = l;
+                trailing_zeros = t;
+            }
+            const meaningful = xor >> @intCast(trailing_zeros);
+            try bit_writer.writeBits(meaningful, meaningful_len);
+            prev_value_bits = current_value_bits;
+        }
+    }
+    try bit_writer.flushBits();
+}
+
+/// Decompress `compressed_values` produced by "Gorilla" and write the
+/// result to `decompressed_values`. If an error occurs it is returned.
+pub fn decompress(allocator: Allocator, compressed_values: []const u8, decompressed_values: *ArrayList(f64)) Error!void {
+    var offset: usize = 0;
+    const value_count = try shared_functions.readOffsetValue(u64, compressed_values, &offset);
+
+    if (value_count == 0) return;
+
+    // Every non-empty Gorilla stream must contain the count header and first uncompressed value.
+    if (compressed_values.len < 16) return Error.UnsupportedInput;
+
+    // The header gives the exact output length, so reserve it once and append without growth checks.
+    try decompressed_values.ensureTotalCapacity(allocator, @intCast(value_count));
+
+    const first_value = try shared_functions.readOffsetValue(f64, compressed_values, &offset);
+    const dtype_bit_len: u64 = @bitSizeOf(@TypeOf(first_value));
+    decompressed_values.appendAssumeCapacity(first_value);
+
+    var bit_reader = shared_structs.BulkBitReader.init(compressed_values[offset..]);
+
+    var current_value_bits: u64 = @bitCast(first_value);
+    var leading: u6 = 0;
+    var trailing: u6 = 0;
+    var window: u7 = 0;
+    while (decompressed_values.items.len < value_count) {
+        const ident_bit = bit_reader.readBitsNoEof(u1, 1) catch return Error.ByteStreamError;
+        if (ident_bit != 0) {
+            const window_bit = bit_reader.readBitsNoEof(u1, 1) catch return Error.ByteStreamError;
+            if (window_bit != 0) {
+                leading = bit_reader.readBitsNoEof(u6, 5) catch return Error.ByteStreamError;
+                window = (bit_reader.readBitsNoEof(u7, 6) catch return Error.ByteStreamError) + 1;
+                trailing = @intCast(dtype_bit_len - leading - window);
+            }
+            const xor_bits = (bit_reader.readBitsNoEof(u64, window) catch return Error.ByteStreamError) << trailing;
+            current_value_bits ^= xor_bits;
+
+        }
+        const value: f64 = @bitCast(current_value_bits);
+        decompressed_values.appendAssumeCapacity(value);
+    }
+}
+
+test "gorilla can always compress and decompress" {
+    const allocator = testing.allocator;
+    const data_distributions = &[_]tester.DataDistribution{
+        .FiniteRandomValues,
+        .LinearFunctions,
+        .BoundedRandomValues,
+        .SinusoidalFunction,
+        .LinearFunctionsWithNansAndInfinities,
+        .RandomValuesWithNansAndInfinities,
+        .SinusoidalFunctionWithNansAndInfinities,
+        .BoundedRandomValuesWithNansAndInfinities,
+    };
+
+    // This function evaluates Gorilla using all data distribution stored in
+    // `data_distribution`. The error bound is ignored as RLE does not use it.
+    try tester.testLosslessMethod(
+        allocator,
+        Method.Gorilla,
+        data_distributions,
+    );
+}
+
+test "gorilla compresses repeated values" {
+    const allocator = testing.allocator;
+
+    var uncompressed_values = ArrayList(f64).empty;
+    defer uncompressed_values.deinit(allocator);
+
+    // Generate a random number of `distinct_elements` that will be repeated a random number of times
+    // to test that RLE can compress repeated values.
+    const distinct_elements: usize = tester.generateBoundRandomInteger(
+        usize,
+        tester.global_at_least,
+        tester.global_at_most,
+        null,
+    );
+
+    for (0..distinct_elements) |_| {
+        const random_value = tester.generateRandomValue(null);
+        const repeat: usize = tester.generateBoundRandomInteger(
+            usize,
+            tester.global_at_least,
+            tester.global_at_most,
+            null,
+        );
+        for (0..repeat) |_| {
+            try uncompressed_values.append(allocator, random_value);
+        }
+    }
+
+    const method_configuration = "{}";
+
+    var compressed_values = try tersets.compress(
+        allocator,
+        uncompressed_values.items,
+        Method.Gorilla,
+        method_configuration,
+    );
+    defer compressed_values.deinit(allocator);
+
+    var decompressed_values = try tersets.decompress(allocator, compressed_values.items);
+    defer decompressed_values.deinit(allocator);
+
+    try testing.expect(shared_functions.isWithinErrorBound(
+        uncompressed_values.items,
+        decompressed_values.items,
+        0.0,
+    ));
+}
+
+test "check rle configuration parsing" {
+    // Tests the configuration parsing and functionality of the `compressMidrange` function.
+    // The test verifies that the provided configuration is correctly interpreted and
+    // that the `configuration.EmptyConfiguration` is expected in the function.
+    const allocator = testing.allocator;
+
+    const uncompressed_values = &[4]f64{ 19.0, 48.0, 29.0, 3.0 };
+
+    var compressed_values = ArrayList(u8).empty;
+    defer compressed_values.deinit(allocator);
+
+    const method_configuration =
+        \\ {}
+    ;
+
+    // The configuration is properly defined. No error expected.
+    try compress(
+        allocator,
+        uncompressed_values,
+        &compressed_values,
+        method_configuration,
+    );
+}

--- a/src/lossless_compression/gorilla.zig
+++ b/src/lossless_compression/gorilla.zig
@@ -32,7 +32,7 @@ const shared_structs = @import("../utilities/shared_structs.zig");
 /// Compresses the `uncompressed_values` using "Gorilla". The function writes the
 /// result to `compressed_values`. The `method_configuration` is expected to be `EmptyConfiguration`,
 /// otherwise an error is returned instead of ignoring the configuration. The `allocator` is used
-/// to allocate the `method_configuration` p arser's memory. If an error occurs it is returned.
+/// to allocate the `method_configuration` parser's memory. If an error occurs it is returned.
 pub fn compress(
     allocator: Allocator,
     uncompressed_values: []const f64,

--- a/src/lossless_compression/gorilla.zig
+++ b/src/lossless_compression/gorilla.zig
@@ -145,7 +145,7 @@ test "gorilla can always compress and decompress" {
     };
 
     // This function evaluates Gorilla using all data distribution stored in
-    // `data_distribution`. The error bound is ignored as RLE does not use it.
+    // `data_distribution`. The error bound is ignored as Gorilla does not use it.
     try tester.testLosslessMethod(
         allocator,
         Method.Gorilla,
@@ -160,7 +160,7 @@ test "gorilla compresses repeated values" {
     defer uncompressed_values.deinit(allocator);
 
     // Generate a random number of `distinct_elements` that will be repeated a random number of times
-    // to test that RLE can compress repeated values.
+    // to test that Gorilla can compress repeated values.
     const distinct_elements: usize = tester.generateBoundRandomInteger(
         usize,
         tester.global_at_least,
@@ -201,8 +201,7 @@ test "gorilla compresses repeated values" {
     ));
 }
 
-test "check rle configuration parsing" {
-    // Tests the configuration parsing and functionality of the `compressMidrange` function.
+test "check gorilla configuration parsing" {
     // The test verifies that the provided configuration is correctly interpreted and
     // that the `configuration.EmptyConfiguration` is expected in the function.
     const allocator = testing.allocator;

--- a/src/lossless_compression/gorilla.zig
+++ b/src/lossless_compression/gorilla.zig
@@ -125,7 +125,6 @@ pub fn decompress(allocator: Allocator, compressed_values: []const u8, decompres
             }
             const xor_bits = (bit_reader.readBitsNoEof(u64, window) catch return Error.ByteStreamError) << trailing;
             current_value_bits ^= xor_bits;
-
         }
         const value: f64 = @bitCast(current_value_bits);
         decompressed_values.appendAssumeCapacity(value);

--- a/src/lossless_compression/gorilla.zig
+++ b/src/lossless_compression/gorilla.zig
@@ -45,10 +45,11 @@ pub fn compress(
         method_configuration,
     );
 
+    // Store the value count so decompression can ignore padding bits after the stream is flushed.
     try shared_functions.appendValue(allocator, u64, @intCast(uncompressed_values.len), compressed_values);
     if (uncompressed_values.len == 0) return;
 
-    // Store first value and xor subsequent values against it
+    // Store first value uncompressed
     const first_value: f64 = uncompressed_values[0];
     try shared_functions.appendValue(allocator, f64, first_value, compressed_values);
 
@@ -57,6 +58,8 @@ pub fn compress(
     var bit_writer = try shared_structs.BulkBitWriter.init(allocator, compressed_values);
 
     var prev_value_bits: u64 = @bitCast(first_value);
+
+    // Gorilla tracks the number of leading zeros and trailing zeros to set the header
     var leading_zeros: u8 = dtype_bit_len + 1;
     var trailing_zeros: u8 = dtype_bit_len + 1;
     var meaningful_len: u8 = 0;
@@ -64,14 +67,15 @@ pub fn compress(
         const current_value_bits: u64 = @bitCast(value);
         const xor = prev_value_bits ^ current_value_bits;
         if (xor == 0) {
+            // write 0b0 for repeated value
             try bit_writer.writeBits(@as(u1, 0), 1);
         } else {
-            // write header
             try bit_writer.writeBits(@as(u1, 1), 1);
+            // compute leading and trailing zeros
             const l: u5 = @min(@clz(xor), 31);
             const t: u8 = @ctz(xor);
             if (l >= leading_zeros and t >= trailing_zeros) {
-                // nested region
+                // nested region, don't change leading/trailing count
                 try bit_writer.writeBits(@as(u1, 0), 1);
             } else {
                 // not nested, need to first record the new leading/trailing count
@@ -82,6 +86,7 @@ pub fn compress(
                 leading_zeros = l;
                 trailing_zeros = t;
             }
+            // store meaningful bits from xor value
             const meaningful = xor >> @intCast(trailing_zeros);
             try bit_writer.writeBits(meaningful, meaningful_len);
             prev_value_bits = current_value_bits;
@@ -117,10 +122,16 @@ pub fn decompress(allocator: Allocator, compressed_values: []const u8, decompres
     while (decompressed_values.items.len < value_count) {
         const ident_bit = bit_reader.readBitsNoEof(u1, 1) catch return Error.ByteStreamError;
         if (ident_bit != 0) {
+            // change current value if header begins with 1
             const window_bit = bit_reader.readBitsNoEof(u1, 1) catch return Error.ByteStreamError;
             if (window_bit != 0) {
+                // change current leading and trailing count
                 leading = bit_reader.readBitsNoEof(u6, 5) catch return Error.ByteStreamError;
                 window = (bit_reader.readBitsNoEof(u7, 6) catch return Error.ByteStreamError) + 1;
+                if (@as(u8, leading) + @as(u8, window) > dtype_bit_len) {
+                    // leading zeros and window should be <= dtype bits, otherwise header is corrupted
+                    return Error.CorruptedCompressedData;
+                }
                 trailing = @intCast(dtype_bit_len - leading - window);
             }
             const xor_bits = (bit_reader.readBitsNoEof(u64, window) catch return Error.ByteStreamError) << trailing;
@@ -199,6 +210,26 @@ test "gorilla compresses repeated values" {
         decompressed_values.items,
         0.0,
     ));
+}
+
+test "gorilla correctly errors for malformed headers" {
+    const allocator = testing.allocator;
+
+    const corrupt_compressed = &[_]u8{ 
+        // vlen bytes
+        0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        // first literal
+        0xDE, 0xAD, 0xFA, 0xDE, 0x00, 0x00, 0x00, 0x00,
+        // corrupt header
+        0xFF, 0xFF, 0xFF, 0xFF,
+    };
+    var uncompressed_values = ArrayList(f64).empty;
+    defer uncompressed_values.deinit(allocator);
+
+    try std.testing.expectError(
+        Error.CorruptedCompressedData,
+        decompress(allocator, corrupt_compressed, &uncompressed_values)
+    );
 }
 
 test "check gorilla configuration parsing" {

--- a/src/tersets.zig
+++ b/src/tersets.zig
@@ -55,6 +55,7 @@ const rle_encoding = @import("lossless_compression/run_length_encoding.zig");
 const delta_encoding = @import("lossless_compression/bitpacked_delta_encoding.zig");
 const chimp64 = @import("lossless_compression/chimp64.zig");
 const chimp128 = @import("lossless_compression/chimp128.zig");
+const gorilla = @import("lossless_compression/gorilla.zig");
 
 const extractors = @import("utilities/extractors.zig");
 const tester = @import("tester.zig");
@@ -105,6 +106,7 @@ pub const Method = enum {
     DiscreteFourierTransform,
     MacaqueS,
     MacaqueV,
+    Gorilla,
 };
 
 /// Compress `uncompressed_values` using `method` and its `configuration` and returns the results
@@ -322,6 +324,14 @@ pub fn compress(
                 configuration,
             );
         },
+        .Gorilla => {
+            try gorilla.compress(
+                allocator,
+                uncompressed_values,
+                &compressed_values,
+                configuration,
+            );
+        },
         .Uncompressed => {
             for (uncompressed_values) |value| {
                 const value_as_bytes: [8]u8 = @bitCast(value);
@@ -420,6 +430,9 @@ pub fn decompress(
         },
         .MacaqueV => {
             try macaque.decompressMacaqueV(allocator, compressed_values_slice, &decompressed_values);
+        },
+        .Gorilla => {
+            try gorilla.decompress(allocator, compressed_values_slice, &decompressed_values);
         },
         .Uncompressed => {
             if (compressed_values_slice.len % 8 != 0) return Error.CorruptedCompressedData;
@@ -584,6 +597,7 @@ pub fn extract(
         .Chimp128,
         .MacaqueS,
         .MacaqueV,
+        .Gorilla,
         => {
             return Error.UnsupportedMethod;
         },
@@ -734,6 +748,7 @@ pub fn rebuild(
         .Chimp128,
         .MacaqueS,
         .MacaqueV,
+        .Gorilla,
         => {
             return Error.UnsupportedMethod;
         },
@@ -782,7 +797,8 @@ test "extract and rebuild works for any compression method supported" {
             method == Method.Chimp64 or
             method == Method.Chimp128 or
             method == Method.MacaqueS or
-            method == Method.MacaqueV)
+            method == Method.MacaqueV or
+            method == Method.Gorilla)
         {
             // These compression methods are not supported for extraction
             // of the coefficients and indices. This is because even small


### PR DESCRIPTION
This adds the Gorilla lossless compression algorithm to TerseTS.

### Summary

This PR implements the XOR based compression algorithm for floating point time series data as introduced in the Gorilla paper.

- Closes #21 
- Based on [Gorilla: A Fast, Scalable, In-Memory Time Series Database](https://www.vldb.org/pvldb/vol8/p1816-teller.pdf)

### Files Added/Modified

- New method file: `src/lossless_compression/gorilla.zig`
- src/tersets.zig - added Gorilla enum variant
- src/capi.zig - extended test to cover Gorilla enum
- src/configuration.zig - added empty configuration for Gorilla

### Testing

- Unit tests added that exercise repeated value compression and that random values, linear/sinusoidal functions, nans, infinities compress correctly.
